### PR TITLE
커뮤니티 상세 Modal 컴포넌트 수정(3가지 Type 으로 작성)

### DIFF
--- a/src/components/commnunityDetail/Comment.tsx
+++ b/src/components/commnunityDetail/Comment.tsx
@@ -1,7 +1,8 @@
 import { useState } from 'react'
 import { formatDate } from '../../lib'
 import type { commentData } from '../../types'
-import ModalCommentDel from './ModalCommentDel'
+import CommonModal from '@components/common/Modal'
+import { Button } from '@components/common'
 
 export default function Comment({
   commentData: { name, date, content, imgUrl },
@@ -25,11 +26,32 @@ export default function Comment({
           >
             삭제
           </div>
+          {
+            <CommonModal
+              isOpen={isModal}
+              onClose={() => setIsModal(false)}
+              position="center-bg"
+              title="댓글을 삭제하시겠습니까?"
+            >
+              <Button
+                fullWidth={false}
+                className="flex justify-center items-center px-[24px] py-[18px] bg-[#efe6fc] text-[16px] text-[#4e01b3] font-[600] rounded-[100px] h-[43px] w-[76px]"
+                onClick={() => setIsModal(false)}
+              >
+                취소
+              </Button>
+              <Button
+                fullWidth={false}
+                className="flex justify-center items-center px-[24px] py-[18px] bg-[#6201e0] text-[16px] text-[#fafafa] font-[600] rounded-[100px] h-[43px] w-[76px]"
+                onClick={() => setIsModal(false)}
+              >
+                확인
+              </Button>
+            </CommonModal>
+          }
         </div>
         <div className="text-[#000000] text-[16px] font-[400]">{content}</div>
       </div>
-      {isModal && <ModalCommentDel setIsModal={setIsModal} />}
     </div>
   )
 }
-

--- a/src/components/commnunityDetail/Comment.tsx
+++ b/src/components/commnunityDetail/Comment.tsx
@@ -30,7 +30,7 @@ export default function Comment({
             <CommonModal
               isOpen={isModal}
               onClose={() => setIsModal(false)}
-              position="center-bg"
+              position="inline"
               title="댓글을 삭제하시겠습니까?"
             >
               <Button

--- a/src/components/common/Modal.tsx
+++ b/src/components/common/Modal.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef } from 'react'
+import { createPortal } from 'react-dom'
 
 interface CommonModalProps {
   title: string
@@ -64,12 +65,13 @@ export default function CommonModal({
     return modalContent
   }
 
-  return (
+  return createPortal(
     <div
       className={`fixed inset-0 z-50 flex items-center justify-center ${position === 'center-bg' ? 'bg-[rgba(0,0,0,0.2)]' : ''}`}
       onClick={onClose}
     >
       {modalContent}
-    </div>
+    </div>,
+    document.body
   )
 }

--- a/src/components/common/Modal.tsx
+++ b/src/components/common/Modal.tsx
@@ -1,63 +1,75 @@
-import React, { useEffect } from 'react'
+import React, { useEffect, useRef } from 'react'
 
 interface CommonModalProps {
+  title: string
   isOpen: boolean
   onClose: () => void
   children: React.ReactNode
+  position?: 'center' | 'inline' | 'center-bg'
 }
 
 export default function CommonModal({
   isOpen,
   onClose,
   children,
+  position = 'center',
+  title,
 }: CommonModalProps) {
+  const modalRef = useRef<HTMLDivElement>(null)
+
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') {
-        onClose()
+      if (e.key === 'Escape') onClose()
+    }
+    // 외부 클릭 시 창닫기
+    const handleClickOutside = (e: MouseEvent) => {
+      if (
+        modalRef.current && // ref current 가 존재하고
+        e.target instanceof Node && // 클릭 이 node 이고
+        !modalRef.current.contains(e.target) // null 이 아닐때
+      ) {
+        onClose() // 창닫힘
       }
     }
 
     if (isOpen) {
       window.addEventListener('keydown', handleKeyDown)
+      if (position === 'inline') {
+        document.addEventListener('mousedown', handleClickOutside)
+      }
     }
 
     return () => {
       window.removeEventListener('keydown', handleKeyDown)
+      if (position === 'inline') {
+        document.removeEventListener('mousedown', handleClickOutside)
+      }
     }
-  }, [isOpen, onClose])
+  }, [isOpen, onClose, position])
 
   if (!isOpen) return null
 
+  const modalContent = (
+    <div
+      ref={modalRef}
+      onClick={(e) => e.stopPropagation()}
+      className={`${position === 'inline' ? 'absolute top-[-70px] left-[300px]' : ''} w-[428px] h-[162px] bg-white shadow-[0_4px_16px_rgba(0,0,0,0.25)] rounded-[24px] p-[24px] flex flex-col justify-between`}
+    >
+      <div className="text-[14px] mb-[12px]">{title}</div>
+      <div className="flex justify-end gap-[12px]">{children}</div>
+    </div>
+  )
+
+  if (position === 'inline') {
+    return modalContent
+  }
+
   return (
     <div
-      className="absolute z-50 top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 bg-opacity-50"
+      className={`fixed inset-0 z-50 flex items-center justify-center ${position === 'center-bg' ? 'bg-[rgba(0,0,0,0.2)]' : ''}`}
       onClick={onClose}
     >
-      <div
-        role="dialog"
-        aria-modal="true"
-        onClick={(e) => e.stopPropagation()}
-        className=" w-[428px] h-[162px] bg-white shadow-[0_4px_16px_rgba(0,0,0,0.25)] rounded-[24px] p-[24px] flex flex-col justify-between"
-      >
-        <div>{children}</div>{' '}
-        <div className="flex justify-end gap-[12px]">
-          <button
-            onClick={onClose}
-            className="flex justify-center items-center px-[24px] py-[18px] bg-[#efe6fc] text-[16px] text-[#4e01b3] font-[600] rounded-[100px] h-[43px] w-[76px]"
-          >
-            취소
-          </button>
-          <button
-            onClick={onClose}
-            className="flex justify-center items-center px-[24px] py-[18px] bg-[#6201e0] text-[16px] text-[#fafafa] font-[600] rounded-[100px] h-[43px] w-[76px]"
-          >
-            확인
-          </button>
-        </div>
-      </div>
+      {modalContent}
     </div>
   )
 }
-
-//const [open, setOpen] = useState(false);<CommonModal isOpen={open} onClose={() => setOpen(false)} title="모달 제목"><p>모달 내용</p></CommonModal>


### PR DESCRIPTION
## ✅ PR 요약

- 관련 이슈 번호 : #32 
- 작업요약 : 커뮤니티 상세페이지용 모달 컴포넌트 작성

<!-- ex: feat: 로그인 페이지 구현 -->

## 📋 상세 내용

<!-- 어떤 작업을 했는지 간단히 설명 -->
1. position 속성 : inline, cetner, center-bg 에 따라 모달위치 다르게 및 배경 어둡게 설정
2. esc 버튼 및 외부 클릭 시 모달창 닫히게 변경



## 📸 스크린샷 (선택)

### 1)``position ="inline"`` 으로 작성 시 삭제 버튼 클릭 시 바로옆에 모달이 나타남
![image](https://github.com/user-attachments/assets/f274e7bd-a7fe-40f0-85ff-1f2126e1573c)


### 2) ``position ="center"`` 으로 작성 시 삭제 버튼 클릭 시 화면 정 중앙에 나타남
<img width="1000" alt="image" src="https://github.com/user-attachments/assets/543e07a1-e9f1-4165-a22b-5ecb9eb98cb2" />


### 3) ``position ="center-bg"`` 으로 작성 시 삭제 버튼 클릭 시 화면 정 중앙에 나타나며 배경을 어둡게 함
<img width="1069" alt="image" src="https://github.com/user-attachments/assets/79bdf470-56ad-495c-9873-4d789cf384cb" />

<!-- UI 변경 시 첨부 -->

## 📝 기타 참고사항

## 🧪 PR Check

<!-- 직접 테스트한 내용, 어떻게 동작을 확인했는지 작성 -->

- [x] 정상 동작 확인
- [x] UI 렌더링 확인
- [x] 기능 동작 확인
- [x] lint, type-check, build 오류 확인
