### PR TITLE
✨ feat     : 커뮤니티 상세페이지 와 footer UI 겹침 수정

### DIFF
--- a/src/pages/CommunityDetail.tsx
+++ b/src/pages/CommunityDetail.tsx
@@ -47,8 +47,8 @@ export default function CommunityDetail() {
   }
 
   return (
-    <div className="absolute left-1/2 top-[254px] transform -translate-x-1/2">
-      <div className="flex flex-col items-center w-[944px] h-[1165px] gap-[100px]">
+    <div className="flex justify-center mt-[142px]">
+      <div className="flex flex-col items-center w-[944px] gap-[100px]">
         <div className="flex flex-col gap-[24px] w-full">
           <div className="flex flex-col gap-[24px] border-b-[1px] pb-[14px] border-[#cecece]">
             <div className="flex flex-col gap-[24px]">
@@ -67,7 +67,7 @@ export default function CommunityDetail() {
                 </div>
               </div>
             </div>
-            <div className="flex justify-between items-center">
+            <div className="flex items-center justify-between">
               <div className="flex items-center gap-[16px] text-[16px] font-[500] text-[#9d9d9d] ">
                 <div>조회수 60</div>
                 <div>좋아요 2</div>
@@ -117,7 +117,7 @@ export default function CommunityDetail() {
             />
           </div>
           <div className="flex flex-col w-full gap-[20px]">
-            <div className="flex justify-between items-center w-full">
+            <div className="flex items-center justify-between w-full">
               <div className="text-[#121212] text-[20px] font-[700]">
                 {Array.isArray(comments)
                   ? `댓글 ${comments.length}개`
@@ -129,7 +129,7 @@ export default function CommunityDetail() {
                   className="text-sm text-gray-700 hover:text-[#6202E0] flex items-center cursor-pointer"
                 >
                   {selectedSort}
-                  <LuArrowUpDown className="ml-2 w-4 h-4" />
+                  <LuArrowUpDown className="w-4 h-4 ml-2" />
                 </button>
 
                 {sortDropdownOpen && (
@@ -157,7 +157,7 @@ export default function CommunityDetail() {
                 <Comment key={commentData.id} commentData={commentData} />
               ))}
             </div>
-            <div className="flex justify-center items-center">
+            <div className="flex items-center justify-center">
               <CommentLoading />
             </div>
           </div>


### PR DESCRIPTION
footer UI 가 커뮤니티 상세 페이지 와 UI 가 겹치는 문제 발생.
position 속성 및 height 속성 수정

## ✅ PR 요약

- 관련 이슈 번호 : #55 
- 작업요약 : 커뮤니티 상세 페이지의 css 속성 수정

<!-- ex: feat: 로그인 페이지 구현 -->

## 📋 상세 내용

- position : absolute 삭제
- 커뮤니티 상세 페이지의 height 높이 삭제하여 내부 컨텐츠의 크기에 따라 높이가 변경되도록 함

## 📸 스크린샷 (선택)

<!-- UI 변경 시 첨부 -->

### < 기존 UI : footer 와 상세페이지 겹칩>
<kbd><img width="1327" alt="image" src="https://github.com/user-attachments/assets/f32ae178-80c7-4e71-9c5f-43e430f27463" /></kbd>
  <br>        
  
### < 변경 UI : footer 가 상세페이지 아래에 나타남>
<kbd>![image](https://github.com/user-attachments/assets/13d34f97-4495-4461-9717-87eaec20d447)</kbd>


## 📝 기타 참고사항

## 🧪 PR Check

<!-- 직접 테스트한 내용, 어떻게 동작을 확인했는지 작성 -->

- [x] 정상 동작 확인
- [x] UI 렌더링 확인
- [x] 기능 동작 확인
- [x] lint, type-check, build 오류 확인
