### PR TITLE
상세페이지 댓글 멘션 로직 수정

### DIFF
--- a/src/components/commnunityDetail/Comment.tsx
+++ b/src/components/commnunityDetail/Comment.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { formatDate } from '../../lib'
 import type { commentData } from '../../types'
 import CommonModal from '@components/common/Modal'
@@ -11,6 +11,18 @@ export default function Comment({
 }) {
   const [isModal, setIsModal] = useState(false)
   const commentDate = formatDate(date)
+  const contentRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (contentRef.current) {
+      const regex = /@([\wㄱ-ㅎㅏ-ㅣ가-힣]{1,})/g
+      const replaced = content.replace(regex, (match) => {
+        return `<span class="font-semibold text-red-400 bg-gray-300 rounded-md p-0.5">${match}</span>`
+      })
+      contentRef.current.innerHTML = replaced
+    }
+  }, [content])
+
   return (
     <div className="flex gap-[17px] w-full relative">
       <img src={imgUrl} className="w-[48px] h-[48px] rounded-[50%] " />
@@ -50,7 +62,9 @@ export default function Comment({
             </CommonModal>
           }
         </div>
-        <div className="text-[#000000] text-[16px] font-[400]">{content}</div>
+        <div ref={contentRef} className="text-[#000000] text-[16px] font-[400]">
+          {content}
+        </div>
       </div>
     </div>
   )

--- a/src/components/commnunityDetail/Comment.tsx
+++ b/src/components/commnunityDetail/Comment.tsx
@@ -3,6 +3,7 @@ import { formatDate } from '../../lib'
 import type { commentData } from '../../types'
 import CommonModal from '@components/common/Modal'
 import { Button } from '@components/common'
+import { commentsMockData } from './mockData'
 
 export default function Comment({
   commentData: { name, date, content, imgUrl },
@@ -17,7 +18,11 @@ export default function Comment({
     if (contentRef.current) {
       const regex = /@([\wㄱ-ㅎㅏ-ㅣ가-힣]{1,})/g
       const replaced = content.replace(regex, (match) => {
-        return `<span class="font-semibold text-red-400 bg-gray-300 rounded-md p-0.5">${match}</span>`
+        const names = commentsMockData.map((comment) => `@${comment.name}`)
+        if (names.includes(match)) {
+          return `<span class="font-semibold text-red-400 bg-gray-300 rounded-md p-0.5">${match}</span>`
+        }
+        return match
       })
       contentRef.current.innerHTML = replaced
     }

--- a/src/components/commnunityDetail/ModalMention.tsx
+++ b/src/components/commnunityDetail/ModalMention.tsx
@@ -17,10 +17,13 @@ export default function ModalMention({
   const handleSelect = (userName: string) => {
     if (!textareaRef.current) return
     const cursorPos = textareaRef.current.selectionStart
-    const beforeCursor = text.slice(0, cursorPos)
-    const afterCursor = text.slice(cursorPos)
+    const beforeCursor = text.slice(0, cursorPos) // 커서 앞쪽 글자 선택
+    const afterCursor = text.slice(cursorPos) // 커서 뒤쪽 글자 선택
 
-    const replaced = beforeCursor.replace(/@([\w가-힣]{1,})$/, `@${userName} `)
+    const replaced = beforeCursor.replace(
+      /@([\wㄱ-ㅎㅏ-ㅣ가-힣]{1,})$/, // '@뒤문자' 선택
+      `@${userName} ` // '@userName' 으로 대체
+    )
     const newText = replaced + afterCursor
 
     setText(newText)

--- a/src/components/commnunityDetail/mockData.ts
+++ b/src/components/commnunityDetail/mockData.ts
@@ -25,7 +25,7 @@ export const commentsMockData = [
     id: 4,
     name: '김지훈',
     date: '2025-06-20T12:00:00.000Z',
-    content: '정말 유익한 내용이에요! @박민수',
+    content: '정말 @김민수 유익한 내용이에요! @박민수',
     imgUrl: 'https://i.pravatar.cc/150?img=4',
   },
   {

--- a/src/components/commnunityDetail/mockData.ts
+++ b/src/components/commnunityDetail/mockData.ts
@@ -17,7 +17,7 @@ export const commentsMockData = [
     id: 3,
     name: '박민수',
     date: '2025-06-21T09:45:00.000Z',
-    content: '질문이 있는데 답변 부탁드려요.',
+    content: '@이영희 질문이 있는데 답변 부탁드려요.',
     imgUrl: 'https://i.pravatar.cc/150?img=3',
   },
   // 김씨 성 추가
@@ -25,14 +25,14 @@ export const commentsMockData = [
     id: 4,
     name: '김지훈',
     date: '2025-06-20T12:00:00.000Z',
-    content: '정말 유익한 내용이에요!',
+    content: '정말 유익한 내용이에요! @박민수',
     imgUrl: 'https://i.pravatar.cc/150?img=4',
   },
   {
     id: 5,
     name: '김미영',
     date: '2025-06-19T11:20:00.000Z',
-    content: '잘 읽고 갑니다~',
+    content: '잘 읽고 @김정환 갑니다~',
     imgUrl: 'https://i.pravatar.cc/150?img=5',
   },
   {


### PR DESCRIPTION
## ✅ PR 요약

- 관련 이슈 번호 : #50 
- 작업요약 : 댓글 멘션 로직 수정

<!-- ex: feat: 로그인 페이지 구현 -->

## 📋 상세 내용

<!-- 어떤 작업을 했는지 간단히 설명 -->

1. 자음 1글자로도 유저 이름 검색하기 적용
2. 댓글 에서 mentione된 유저 이름 강조 표시
3. 유저 이름이 있을 경우에만 강조 적용

## 📸 스크린샷 (선택)
1. 자음 1글자로 유저 이름 검색

![멘션 검색기능](https://github.com/user-attachments/assets/7e922921-2d09-4c23-8ecf-47e37be26fb7)




2. 댓글에서 mention 된 유저 이름 강조표기
![image](https://github.com/user-attachments/assets/df9dd1d3-e51c-4d8d-b548-af36446c8fb3)



<!-- UI 변경 시 첨부 -->

## 📝 기타 참고사항

## 🧪 PR Check

<!-- 직접 테스트한 내용, 어떻게 동작을 확인했는지 작성 -->

- [x] 정상 동작 확인
- [x] UI 렌더링 확인
- [x] 기능 동작 확인
- [x] lint, type-check, build 오류 확인
