### PR TITLE
✨ feat: 회원가입/로그인 SNS 버튼 공통 컴포넌트 적용 및 Footer 위치 수정

### DIFF
--- a/src/components/join/EmailVerification.tsx
+++ b/src/components/join/EmailVerification.tsx
@@ -18,7 +18,6 @@ export default function EmailVerification({ email, setEmail }: EmailVerification
 
   return (
     <div className="flex flex-col">
-      {/* 수정: 라벨과 인풋 사이 20px 간격 유지 */}
       <div className="flex gap-[16px] items-center mb-[20px]">
         <label className="text-[16px] font-[500]">
           이메일<span className="text-red-500 ml-1">*</span>

--- a/src/components/join/JoinForm.tsx
+++ b/src/components/join/JoinForm.tsx
@@ -30,25 +30,25 @@ export default function JoinForm() {
         <div className="text-[18px] font-[600]">회원가입</div>
 
         <div className="flex flex-col gap-[44px]">
-  <NameField name={name} setName={setName} />
-  <NicknameField nickname={nickname} setNickname={setNickname} />
-  <BirthField birth={birth} setBirth={setBirth} />
-  <EmailVerification email={email} setEmail={setEmail} />
-  <PhoneVerification
-    phone1={phone1}
-    phone2={phone2}
-    phone3={phone3}
-    setPhone1={setPhone1}
-    setPhone2={setPhone2}
-    setPhone3={setPhone3}
-  />
-  <PasswordFields
-    password={password}
-    confirmPw={confirmPw}
-    setPassword={setPassword}
-    setConfirmPw={setConfirmPw}
-  />
-</div>
+          <NameField name={name} setName={setName} />
+          <NicknameField nickname={nickname} setNickname={setNickname} />
+          <BirthField birth={birth} setBirth={setBirth} />
+          <EmailVerification email={email} setEmail={setEmail} />
+          <PhoneVerification
+            phone1={phone1}
+            phone2={phone2}
+            phone3={phone3}
+            setPhone1={setPhone1}
+            setPhone2={setPhone2}
+            setPhone3={setPhone3}
+          />
+          <PasswordFields
+            password={password}
+            confirmPw={confirmPw}
+            setPassword={setPassword}
+            setConfirmPw={setConfirmPw}
+          />
+        </div>
 
           {/* 가입 버튼 */}
           <SubmitButton

--- a/src/components/join/PasswordFields.tsx
+++ b/src/components/join/PasswordFields.tsx
@@ -24,7 +24,6 @@ export default function PasswordFields({
 
   return (
     <div className="flex flex-col">
-      {/* 수정: 라벨 아래 20px 간격 추가 */}
       <div className="inline-flex items-center mb-[20px]">
         <span className="text-[16px] font-[500] text-[#121212]">비밀번호</span>
         <span className="text-red-500 ml-[4px] text-[16px]">*</span>

--- a/src/components/join/PhoneVerification.tsx
+++ b/src/components/join/PhoneVerification.tsx
@@ -30,7 +30,6 @@ export default function PhoneVerification({
 
   return (
     <div className="flex flex-col">
-      {/* 수정: mb-[20px] 추가 */}
       <label className="text-[16px] font-[500] mb-[20px]">
         휴대전화<span className="text-red-500 ml-1">*</span>
       </label>
@@ -73,6 +72,7 @@ export default function PhoneVerification({
             className="min-w-0 grow w-[108px]"
           />
         </div>
+
         {/* 인증번호전송 버튼 */}
         <Button
           fullWidth={false}
@@ -88,7 +88,6 @@ export default function PhoneVerification({
         </Button>
       </div>
 
-      {/* 수정: mt-[8px] 오타 수정 */}
       {(isPhoneError || isPhoneSuccess) && (
         <div className="pl-[2px] mt-[8px]">
           {isPhoneError && (

--- a/src/pages/Join.tsx
+++ b/src/pages/Join.tsx
@@ -1,11 +1,11 @@
 import logo from '../assets/ozcoding_logo_black.png'
-import cacaologo from '../assets/cacaologo.png'
-import naverlogo from '../assets/neverlogo.png'
 import { Link } from 'react-router'
+import SnsAuthButton from '../components/common/SnsAuthButton';
+
 
 export default function Join() {
   return (
-    <div className="w-full flex flex-col items-center absolute top-[200px]">
+    <div className="w-full flex flex-col items-center mt-[88px]">
       <div className="flex flex-col items-center w-[348px] gap-[64px]">
         <div className="flex flex-col items-center gap-[27px]">
           <img src={logo} alt="" className="h-[24px]" />
@@ -19,24 +19,19 @@ export default function Join() {
           </div>
         </div>
         <div className="flex flex-col items-center gap-[36px] w-full">
-          <div className="flex flex-col gap-[16px] w-full">
-            <button className="flex justify-center items-center gap-[4px] bg-[#fee500] w-full h-[52px] 
-            text-[#391c1a] text-[16px] rounded-[4px] font-[400]">
-              <img src={cacaologo} className="w-[16px] h-[14px]" />
-              <div>카카오로 3초만에 가입하기</div>
-            </button>
-            <button className="flex justify-center items-center gap-[4px] 
-            bg-[#03c45a] w-full h-[52px] text-[#ffffff] text-[16px] rounded-[4px]">
-              <img src={naverlogo} className="w-[13px] h-[13px]" />
-              <div>네이버로 가입하기</div>
-            </button>
+        <div className="flex flex-col items-center gap-[36px] w-full">
+
+          <div className="flex flex-col gap-[4px] w-full">
+            <SnsAuthButton />
           </div>
+
           <Link
             to="/Join/JoinForm"
-            className="font-[500] text-[16px] text-[#4d4d4d] underline"
+            className="font-normal text-[16px] text-[#4d4d4d] underline decoration-solid"
           >
             일반회원 가입
           </Link>
+        </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## ✅ PR 요약

- 관련 이슈 번호 : 없음
- 작업요약 : 회원가입/로그인 페이지 SNS 버튼 공통 컴포넌트 적용 및 Footer 위치 수정

<!-- ex: feat: 로그인 페이지 구현 -->

## 📋 상세 내용

<!-- 어떤 작업을 했는지 간단히 설명 -->

- SnsAuthButton 공통 컴포넌트를 생성하여 로그인/회원가입 페이지에서 재사용
- 기존 페이지 내 개별 SNS 버튼을 제거하고 공통 컴포넌트로 교체
- 버튼 간 간격은 각 페이지에서 gap으로 제어되도록 구성
- Join.tsx 내 컨테이너에 적용되어 있던 absolute top-[200px] 제거
- mt-[200px]으로 대체하여 Footer가 하단에 자연스럽게 배치되도록 수정

## 📸 스크린샷 (선택)

<!-- UI 변경 시 첨부 -->

## 📝 기타 참고사항

## 🧪 PR Check

<!-- 직접 테스트한 내용, 어떻게 동작을 확인했는지 작성 -->

- [ ] 정상 동작 확인
- [ ] UI 렌더링 확인
- [ ] 기능 동작 확인
- [ ] lint, type-check, build 오류 확인
