### PR TITLE
✨ feat: 휴대폰/생년월일 입력 필드 숫자만 허용 및 자리수 제한

### DIFF
--- a/src/components/join/BirthField.tsx
+++ b/src/components/join/BirthField.tsx
@@ -16,7 +16,11 @@ export default function BirthField({ birth, setBirth }: BirthFieldProps) {
       <Input
         type="number"
         value={birth}
-        onChange={(e) => setBirth(e.target.value)}
+        onChange={(e) => {
+          const onlyNumbers = e.target.value.replace(/[^0-9]/g, '');
+          const limited = onlyNumbers.slice(0, 8);
+          setBirth(limited);
+        }}
         noMarginBottom
         focusBorderColor="focus:border-[#6201E0]"
         placeholder="8자리 입력해주세요 (ex.20001004)"

--- a/src/components/join/PhoneVerification.tsx
+++ b/src/components/join/PhoneVerification.tsx
@@ -38,7 +38,11 @@ export default function PhoneVerification({
         <div className="flex grow min-w-0 gap-[5px] items-center">
           <Input
             value={phone1}
-            onChange={(e) => setPhone1(e.target.value)}
+            onChange={(e) => {
+              const onlyNumbers = e.target.value.replace(/[^0-9]/g, '');
+              const limited = onlyNumbers.slice(0, 4);
+              setPhone1(limited);
+            }}
             placeholder="010"
             fullWidth={false}
             noMarginBottom
@@ -50,7 +54,11 @@ export default function PhoneVerification({
           <span className="text-[14px] text-[#bdbdbd] ">-</span>
           <Input
             value={phone2}
-            onChange={(e) => setPhone2(e.target.value)}
+            onChange={(e) => {
+              const onlyNumbers = e.target.value.replace(/[^0-9]/g, '');
+              const limited = onlyNumbers.slice(0, 4);
+              setPhone2(limited);
+            }}
             placeholder="1234"
             fullWidth={false}
             noMarginBottom
@@ -62,7 +70,11 @@ export default function PhoneVerification({
           <span className="text-[14px] text-[#bdbdbd]">-</span>
           <Input
             value={phone3}
-            onChange={(e) => setPhone3(e.target.value)}
+            onChange={(e) => {
+              const onlyNumbers = e.target.value.replace(/[^0-9]/g, '');
+              const limited = onlyNumbers.slice(0, 4);
+              setPhone3(limited);
+            }}
             placeholder="5678"
             noMarginBottom
             fullWidth={false}

--- a/src/components/login/LoginForm.tsx
+++ b/src/components/login/LoginForm.tsx
@@ -16,6 +16,8 @@ const LoginForm = () => {
   const [openFindPwModal, setOpenFindPwModal] = useState(false) // 비밀번호 찾기 모달
   const [openResetPwModal, setOpenResetPwModal] = useState(false) // 비밀번호 재설정 모달
   const [showFindIdSuccess, setShowFindIdSuccess] = useState(false) // 아이디 찾기 성공 화면
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
 
   return (
     <div className="flex flex-col items-center justify-center bg-white pt-[88px]">
@@ -33,18 +35,22 @@ const LoginForm = () => {
       <LoginButtons />
 
       <div className="w-[348px] pace-y-3 mt-[40px]">
-        <LoginInputs
-          onFindId={() => {
-            setOpenFindIdModal(true)
-            setOpenFindPwModal(false)
-            setOpenResetPwModal(false)
-          }}
-          onFindPw={() => {
-            setOpenFindPwModal(true)
-            setOpenFindIdModal(false)
-            setOpenResetPwModal(false)
-          }}
-        />
+      <LoginInputs
+        email={email}
+        password={password}
+        setEmail={setEmail}
+        setPassword={setPassword}
+        onFindId={() => {
+          setOpenFindIdModal(true);
+          setOpenFindPwModal(false);
+          setOpenResetPwModal(false);
+        }}
+        onFindPw={() => {
+          setOpenFindPwModal(true);
+          setOpenFindIdModal(false);
+          setOpenResetPwModal(false);
+        }}
+      />
 
         {/* 모달 렌더링 담당 (props로 상태 전달) */}
         <LoginModals

--- a/src/components/login/LoginInputs.tsx
+++ b/src/components/login/LoginInputs.tsx
@@ -6,41 +6,56 @@
 import { Input, Button } from '@components/common';
 
 interface Props {
+  email: string;
+  password: string;
+  setEmail: (value: string) => void;
+  setPassword: (value: string) => void;
   onFindId: () => void; // 상위에서 전달된 아이디 찾기 모달 열기 함수
-  onFindPw: () => void; // 상위에서 전달된 비밀번호 찾기 모달 열기 함수
+  onFindPw: () => void;  // 상위에서 전달된 비밀번호 찾기 모달 열기 함수
 }
 
-const LoginInputs = ({ onFindId, onFindPw }: Props) => (
+const LoginInputs = ({
+  email,
+  password,
+  setEmail,
+  setPassword,
+  onFindId,
+  onFindPw,
+}: Props) => (
   <>
-    {/* 이메일 입력창 */}
+    {/* 이메일 입력 */}
     <Input
       type="email"
+      value={email}
+      onChange={(e) => setEmail(e.target.value)}
       placeholder="아이디 (example@gmail.com)"
       noMarginBottom
       className="w-[346px] h-[48px] border border-[#BDBDBD] px-4 py-2 rounded text-[14px] 
-      focus:outline-none text-[#BDBDBD] mb-[12px]"
+      focus:outline-none mb-[12px]"
     />
 
-    {/* 비밀번호 입력창 */}
+    {/* 비밀번호 입력 */}
     <Input
       type="password"
+      value={password}
+      onChange={(e) => setPassword(e.target.value)}
       placeholder="비밀번호 (6~15자의 영문 대소문자, 숫자, 특수문자 포함)"
       className="w-[346px] h-[48px] border border-[#BDBDBD] px-4 py-2 rounded text-[14px] 
-      focus:outline-none text-[#BDBDBD]"
+      focus:outline-none"
     />
 
-    {/* 아이디 / 비번 찾기 링크 */}
+    {/* 아이디 / 비번 찾기 */}
     <div className="flex justify-left gap-2 text-[#4D4D4D] mt-[8px] mb-[12px] text-[14px]">
       <a href="#" role="button" onClick={(e) => { e.preventDefault(); onFindId(); }}>아이디 찾기</a>
       <span>|</span>
       <a href="#" role="button" onClick={(e) => { e.preventDefault(); onFindPw(); }}>비밀번호 찾기</a>
     </div>
 
-    {/* 일반 로그인 버튼 (현재 비활성화 상태) */}
+    {/* 로그인 버튼 */}
     <Button
-      disabled
-      className="w-[348px] h-[52px] bg-[#ECECEC] font-semibold rounded mt-2 
-      cursor-pointer text-[#BDBDBD]"
+      disabled={!email || !password}
+      className={`w-[348px] h-[52px] font-semibold rounded mt-2 
+        ${email && password ? 'bg-[#6201E0] text-white' : 'bg-[#ECECEC] text-[#BDBDBD]'}`}
     >
       일반회원 로그인
     </Button>

--- a/src/components/modals/FindIdModal/FindIdForm.tsx
+++ b/src/components/modals/FindIdModal/FindIdForm.tsx
@@ -68,7 +68,7 @@ const FindIdForm = ({
             type="tel"
             placeholder="숫자만 입력해주세요"
             fullWidth={false}
-            value={phone}
+            value={phone.slice(0, 12)}
             onChange={(e) => onPhoneChange(e.target.value)}
             noMarginBottom
             className="w-[228px] h-[48px] border border-[#BDBDBD] rounded px-3 text-[14px]"

--- a/src/components/modals/FindIdModal/FindIdModal.tsx
+++ b/src/components/modals/FindIdModal/FindIdModal.tsx
@@ -36,6 +36,11 @@ const FindIdModal: React.FC<FindIdModalProps> = ({ onClose, onSuccess }) => {
     }
   };
 
+  const handlePhoneChange = (value: string) => {
+    const onlyNumbers = value.replace(/[^0-9]/g, '');
+    setPhone(onlyNumbers);
+  };
+  
   return (
     <div className="fixed inset-0 bg-[rgba(18,18,18,0.6)] z-50 flex justify-center items-center">
       {/* 모달 레이어 */}
@@ -50,7 +55,7 @@ const FindIdModal: React.FC<FindIdModalProps> = ({ onClose, onSuccess }) => {
           phone={phone}
           showError={showError}
           onNameChange={setName}
-          onPhoneChange={setPhone}
+          onPhoneChange={handlePhoneChange}
           onFindId={handleFindId}
         />
       </div>


### PR DESCRIPTION
## ✅ PR 요약

- 관련 이슈 번호 : 없음
- 작업요약 : 휴대폰 번호, 생년월일 각 칸 입력 시 숫자만 입력되도록 처리

<!-- ex: feat: 로그인 페이지 구현 -->

## 📋 상세 내용

<!-- 어떤 작업을 했는지 간단히 설명 -->

- 휴대폰 번호 각 칸 입력 시 숫자만 입력되도록 처리
- 각 칸당 최대 4자리까지만 입력 가능하도록 slice(0, 4) 적용
- 생년월일 입력 시 숫자만 허용 + 최대 8자리 제한 (YYYYMMDD 포맷)
- 시각적 제한을 위한 maxLength 속성 추가

## 📸 스크린샷 (선택)

<!-- UI 변경 시 첨부 -->

## 📝 기타 참고사항

## 🧪 PR Check

<!-- 직접 테스트한 내용, 어떻게 동작을 확인했는지 작성 -->

- [ ] 정상 동작 확인
- [ ] UI 렌더링 확인
- [ ] 기능 동작 확인
- [ ] lint, type-check, build 오류 확인
