### PR TITLE
✨ feat : 댓글 무한 스크롤로 불러오기 기능 추가

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,0 @@
-VITE_API_BASE_URL=http://localhost:3000
-NODE_ENV=development
-

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,14 +1,13 @@
 import { useState, useEffect } from 'react'
-import { commentsMockData } from '../components/commnunityDetail/mockData'
 import type { commentData } from '../types'
 
 export const useSortComments = (initialOption: string) => {
-  const [comments, setComments] = useState<commentData[]>(commentsMockData)
+  const [comments, setComments] = useState<commentData[]>([])
   const [sortDropdownOpen, setSortDropdownOpen] = useState<boolean>(false)
   const [selectedSort, setSelectedSort] = useState<string>(initialOption)
 
   useEffect(() => {
-    const sorted = [...commentsMockData].sort((a, b) => {
+    const sorted = [...comments].sort((a, b) => {
       const timeA = new Date(a.date).getTime()
       const timeB = new Date(b.date).getTime()
 
@@ -19,6 +18,7 @@ export const useSortComments = (initialOption: string) => {
 
   return {
     comments,
+    setComments,
     sortDropdownOpen,
     selectedSort,
     setSortDropdownOpen,

--- a/src/pages/CommunityDetail.tsx
+++ b/src/pages/CommunityDetail.tsx
@@ -1,218 +1,292 @@
 interface PostData {
-    id: number;
-    category: { id: number; name: string };
-    author_id: number;
-    title: string;
-    content: string;
-    view_count: number;
-    is_visible: boolean;
-    is_notice: boolean;
-    attachments: { id: number; file_url: string; file_name: string }[];
-    images: [{
-        id: number;
-        image_url: string;
-        image_name: string;
-        image_type: string;
-    }];
-    created_at: string;
-    updated_at: string;
+  id: number
+  category: { id: number; name: string }
+  author_id: number
+  title: string
+  content: string
+  view_count: number
+  is_visible: boolean
+  is_notice: boolean
+  attachments: { id: number; file_url: string; file_name: string }[]
+  images: [
+    {
+      id: number
+      image_url: string
+      image_name: string
+      image_type: string
+    },
+  ]
+  created_at: string
+  updated_at: string
 }
 
-import {useRef, useState, useEffect, type SetStateAction} from 'react';
-import { Link } from 'react-router-dom';
-import {useParams} from 'react-router-dom';
-import axios from 'axios';
-import ReactMarkdown from 'react-markdown';
-import remarkGfm from 'remark-gfm';
-import photo from '../assets/profile.png';
-import Comment from '../components/commnunityDetail/Comment';
-import {AiOutlineLike} from 'react-icons/ai';
-import {GoLink} from 'react-icons/go';
-import {LuArrowUpDown} from 'react-icons/lu';
-import CommentLoading from '../components/commnunityDetail/CommentLoading';
-import CommentTextArea from '../components/commnunityDetail/CommentTextArea';
-import {useSortComments} from '../hooks';
-import {URLCopy} from '@lib/index';
-import { IoChatbubbleOutline } from 'react-icons/io5';
+import {
+  useRef,
+  useState,
+  useEffect,
+  type SetStateAction,
+  useCallback,
+} from 'react'
+import { Link } from 'react-router-dom'
+import { useParams } from 'react-router-dom'
+import axios from 'axios'
+import ReactMarkdown from 'react-markdown'
+import remarkGfm from 'remark-gfm'
+import photo from '../assets/profile.png'
+import Comment from '../components/commnunityDetail/Comment'
+import { AiOutlineLike } from 'react-icons/ai'
+import { GoLink } from 'react-icons/go'
+import { LuArrowUpDown } from 'react-icons/lu'
+import CommentLoading from '../components/commnunityDetail/CommentLoading'
+import CommentTextArea from '../components/commnunityDetail/CommentTextArea'
+import { useSortComments } from '../hooks'
+import { URLCopy } from '@lib/index'
+import { IoChatbubbleOutline } from 'react-icons/io5'
+import { commentsMockData } from '@components/commnunityDetail/mockData'
 
 export default function CommunityDetail() {
-    const {id} = useParams();
-    const textareaRef = useRef(null);
-    const [postData, setPostData] = useState<PostData | null>(null);
-    const [isLike, setIsLike] = useState(false);
-    const [likeNum, setLikeNum] = useState(2);
+  const { id } = useParams()
+  const textareaRef = useRef(null)
+  const [postData, setPostData] = useState<PostData | null>(null)
+  const [isLike, setIsLike] = useState(false)
+  const [likeNum, setLikeNum] = useState(2)
 
-    const {
-        comments,
-        sortDropdownOpen,
-        selectedSort,
-        setSortDropdownOpen,
-        setSelectedSort,
-    } = useSortComments('최신순');
+  const [isLoading, setIsLoading] = useState(false)
+  const [hasNext, setHasNext] = useState(true)
+  const [cursor, setCursor] = useState<number | null>(null)
 
-    useEffect(() => {
-        axios
-            .get(`http://localhost:3000/api/v1/community/posts/` + id)
-            .then(res => setPostData(res.data))
-            .catch(err => console.error('게시글 조회 실패:', err));
-    }, [id]);
+  const {
+    comments,
+    setComments,
+    sortDropdownOpen,
+    selectedSort,
+    setSortDropdownOpen,
+    setSelectedSort,
+  } = useSortComments('최신순')
 
-    const handleSort = (option: SetStateAction<string>) => {
-        setSelectedSort(option);
-        setSortDropdownOpen(prev => !prev);
-    };
+  useEffect(() => {
+    axios
+      .get(`http://localhost:3000/api/v1/community/posts/` + id)
+      .then((res) => setPostData(res.data))
+      .catch((err) => console.error('게시글 조회 실패:', err))
+  }, [id])
 
-    const handleClickLike = () => {
-        setLikeNum(prev => (isLike ? prev - 1 : prev + 1));
-        setIsLike(prev => !prev);
-    };
+  // 불러오기 함수
+  const fetchComments = () => {
+    if (isLoading || !hasNext) return
 
-    if (!postData) return <div className="mt-36 text-center">로딩 중...</div>;
+    setIsLoading(true)
 
-    return (
-        <>
-        <div className="flex justify-center mt-[142px]">
-            <div className="relative flex flex-col items-center w-[944px] gap-[100px]">
-                <div className="flex flex-col gap-[24px] w-full">
-                    <div className="flex flex-col gap-[24px] border-b-[1px] pb-[14px] border-[#cecece]">
-                        <div className="flex flex-col gap-[24px]">
-                            <div className="flex gap-[5px] items-center text-[#6201e0] w-full text-[20px] font-[700]">
-                                <div>{postData.category.name}</div>
-                            </div>
-                            <div className="flex justify-between w-full">
-                                <p className="font-[700] text-[23px]">{postData.title}</p>
-                                <div className="flex items-center justify-between w-[101px]">
-                                    <img
-                                        src={photo}
-                                        alt="작성자"
-                                        className="h-[48px] rounded-[50%]"
-                                    />
-                                </div>
-                            </div>
-                        </div>
-                        <div className="flex items-center justify-between">
-                            <div className="flex items-center gap-[16px] text-[16px] font-[500] text-[#9d9d9d]">
-                                <div>조회수 {postData.view_count}</div>
-                                <div>좋아요 {likeNum}</div>
-                                <div>
-                                    {new Date(postData.updated_at).getTime() !== new Date(postData.created_at).getTime()
-                                        ? `수정됨: ${new Date(postData.updated_at).toLocaleString()}`
-                                        : new Date(postData.created_at).toLocaleString()}
-                                </div>
-                            </div>
-                            <div className="flex items-center gap-[10px] text-[#707070] font-[500] text-[16px]">
-                                <Link to={`/CommunityList/CommunityEdit/${postData.id}`} className="text-[#6201e0]">
-                                    수정
-                                </Link>
-                                <div>|</div>
-                                <div>삭제</div>
-                            </div>
-                        </div>
-                    </div>
-                    <div className="prose max-w-none">
-                        <ReactMarkdown
-                            remarkPlugins={[remarkGfm]}
-                            components={{
-                                img: ({node, ...props}) => {
-                                    const src = props.src || '';
-                                    const match = src.match(/^image(\d+)/);
-                                    if (match) {
-                                        const index = parseInt(match[1], 10) - 1;
-                                        const actualSrc = postData.images?.[index].image_url;
-                                        if (actualSrc) {
-                                            return <img {...props} src={actualSrc} alt={props.alt || 'image'}/>;
-                                        } else {
-                                            return null;
-                                        }
-                                    }
-                                    return <img {...props} alt={props.alt || 'image'}/>;
-                                },
-                            }}
-                        >
-                            {postData.content}
-                        </ReactMarkdown>
-                    </div>
+    setTimeout(() => {
+      const currentLength = comments.length
+      const nextBatch = commentsMockData.slice(
+        currentLength,
+        currentLength + 10
+      )
+
+      setComments((prev) => [...prev, ...nextBatch])
+      setHasNext(
+        nextBatch.length === 10 &&
+          currentLength + nextBatch.length < commentsMockData.length
+      )
+
+      setIsLoading(false)
+    }, 2000) // debounce 역할도 겸함
+  }
+
+  useEffect(() => {
+    setComments([])
+    setCursor(0)
+    setHasNext(true)
+    fetchComments()
+  }, [selectedSort])
+
+  const observerRef = useCallback(
+    (node: HTMLDivElement | null) => {
+      if (!node) return
+
+      const observer = new IntersectionObserver(
+        (entries) => {
+          if (entries[0].isIntersecting && !isLoading && hasNext) {
+            fetchComments()
+          }
+        },
+        { threshold: 0.1 }
+      )
+
+      observer.observe(node)
+    },
+    [isLoading, hasNext]
+  )
+
+  const handleSort = (option: SetStateAction<string>) => {
+    setSelectedSort(option)
+    setSortDropdownOpen((prev) => !prev)
+  }
+
+  const handleClickLike = () => {
+    setLikeNum((prev) => (isLike ? prev - 1 : prev + 1))
+    setIsLike((prev) => !prev)
+  }
+
+  if (!postData) return <div className="text-center mt-36">로딩 중...</div>
+
+  return (
+    <div className="flex justify-center mt-[142px]">
+      <div className="relative flex flex-col items-center w-[944px] gap-[100px]">
+        <div className="flex flex-col gap-[24px] w-full">
+          <div className="flex flex-col gap-[24px] border-b-[1px] pb-[14px] border-[#cecece]">
+            <div className="flex flex-col gap-[24px]">
+              <div className="flex gap-[5px] items-center text-[#6201e0] w-full text-[20px] font-[700]">
+                <div>{postData.category.name}</div>
+              </div>
+              <div className="flex justify-between w-full">
+                <p className="font-[700] text-[23px]">{postData.title}</p>
+                <div className="flex items-center justify-between w-[101px]">
+                  <img
+                    src={photo}
+                    alt="작성자"
+                    className="h-[48px] rounded-[50%]"
+                  />
                 </div>
-                <div className="flex flex-col gap-[24px] w-full">
-                    <div className="flex w-full justify-end gap-[12px] pb-[24px] border-b-[1px] border-[#cecece]">
-                        <button
-                            className="flex gap-[4px] items-center text-[#707070] border-[1px] border-[#cecece] py-[10px] px-[16px] rounded-[1000px] w-[62px] h-[38px] cursor-pointer"
-                            onClick={handleClickLike}
-                        >
-                            <AiOutlineLike
-                                className={`h-[18px] w-[18px] ${isLike ? 'text-[#6201e0]' : 'text-[#707070]'}`}
-                            />
-                            <div
-                                className={`text-[12px] font-[500] ${isLike ? 'text-[#6201e0]' : 'text-[#707070]'}`}
-                            >
-                                {likeNum}
-                            </div>
-                        </button>
-                        <button
-                            className="flex gap-[4px] items-center text-[#707070] border-[1px] border-[#cecece] py-[10px] px-[5px] rounded-[1000px] hover:bg-[#ececec] w-[82px] h-[38px] cursor-pointer"
-                            onClick={async () => {
-                                const result = await URLCopy()
-                                alert(
-                                    `${result ? '복사가 완료되었습니다.' : '복사가 실패하였습니다.'}`
-                                )
-                            }}
-                        >
-                            <GoLink className="h-[18px] w-[18px]" />
-                            <div className="text-[12px] font-[500]">공유하기</div>
-                        </button>
-                    </div>
-                    <div className="flex w-full h-[120px] gap-[40px] p-[20px] border-[1px] rounded-[12px] border-[#cecece] focus-within:border-[#6202E0]">
-                        <CommentTextArea
-                            textareaRef={textareaRef}
-                            comments={Array.isArray(comments) ? comments : []}
-                        />
-                    </div>
-                    <div className="flex flex-col w-full gap-[20px]">
-                        <div className="flex items-center justify-between w-full">
-                            <div className="flex items-center gap-[12px]">
-                                <IoChatbubbleOutline className="w-[18px] h-[18px]" />
-                                <div className="text-[#121212] text-[20px]">
-                                    {Array.isArray(comments)
-                                        ? `댓글 ${comments.length}개`
-                                        : '댓글 0개'}
-                                </div>
-                            </div>
-                            <div className="relative">
-                                <button
-                                    onClick={() => setSortDropdownOpen((prev) => !prev)}
-                                    className="text-sm text-gray-700 hover:text-[#6202E0] flex items-center cursor-pointer"
-                                >
-                                    {selectedSort}
-                                    <LuArrowUpDown className="w-4 h-4 ml-2" />
-                                </button>
-                                {sortDropdownOpen && (
-                                    <div
-                                        className="absolute top-[100%] right-0 mt-2 bg-white shadow-lg rounded-xl p-2 w-32 text-sm z-20">
-                                        {['최신순', '오래된 순'].map(option => (
-                                            <div
-                                                key={option}
-                                                onClick={() => handleSort(option)}
-                                                className={`cursor-pointer px-3 py-2 rounded-md text-center transition ${selectedSort === option ? 'bg-purple-100 text-[#6202E0] font-bold' : 'text-gray-700 hover:bg-gray-100'}`}
-                                            >
-                                                {option}
-                                            </div>
-                                        ))}
-                                    </div>
-                                )}
-                            </div>
-                        </div>
-                        <div className="flex flex-col gap-[17px] w-full">
-                            {comments.map(commentData => (
-                                <Comment key={commentData.id} commentData={commentData}/>
-                            ))}
-                        </div>
-                        <div className="flex items-center justify-center">
-                            <CommentLoading/>
-                        </div>
-                    </div>
-                </div>
+              </div>
             </div>
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-[16px] text-[16px] font-[500] text-[#9d9d9d]">
+                <div>조회수 {postData.view_count}</div>
+                <div>좋아요 {likeNum}</div>
+                <div>
+                  {new Date(postData.updated_at).getTime() !==
+                  new Date(postData.created_at).getTime()
+                    ? `수정됨: ${new Date(postData.updated_at).toLocaleString()}`
+                    : new Date(postData.created_at).toLocaleString()}
+                </div>
+              </div>
+              <div className="flex items-center gap-[10px] text-[#707070] font-[500] text-[16px]">
+                <Link
+                  to={`/CommunityList/CommunityEdit/${postData.id}`}
+                  className="text-[#6201e0]"
+                >
+                  수정
+                </Link>
+                <div>|</div>
+                <div>삭제</div>
+              </div>
+            </div>
+          </div>
+          <div className="prose max-w-none">
+            <ReactMarkdown
+              remarkPlugins={[remarkGfm]}
+              components={{
+                img: ({ node, ...props }) => {
+                  const src = props.src || ''
+                  const match = src.match(/^image(\d+)/)
+                  if (match) {
+                    const index = parseInt(match[1], 10) - 1
+                    const actualSrc = postData.images?.[index].image_url
+                    if (actualSrc) {
+                      return (
+                        <img
+                          {...props}
+                          src={actualSrc}
+                          alt={props.alt || 'image'}
+                        />
+                      )
+                    } else {
+                      return null
+                    }
+                  }
+                  return <img {...props} alt={props.alt || 'image'} />
+                },
+              }}
+            >
+              {postData.content}
+            </ReactMarkdown>
+          </div>
         </div>
-        </>
-    );
+        <div className="flex flex-col gap-[24px] w-full">
+          <div className="flex w-full justify-end gap-[12px] pb-[24px] border-b-[1px] border-[#cecece]">
+            <button
+              className="flex gap-[4px] items-center text-[#707070] border-[1px] border-[#cecece] py-[10px] px-[16px] rounded-[1000px] w-[62px] h-[38px] cursor-pointer"
+              onClick={handleClickLike}
+            >
+              <AiOutlineLike
+                className={`h-[18px] w-[18px] ${isLike ? 'text-[#6201e0]' : 'text-[#707070]'}`}
+              />
+              <div
+                className={`text-[12px] font-[500] ${isLike ? 'text-[#6201e0]' : 'text-[#707070]'}`}
+              >
+                {likeNum}
+              </div>
+            </button>
+            <button
+              className="flex gap-[4px] items-center text-[#707070] border-[1px] border-[#cecece] py-[10px] px-[5px] rounded-[1000px] hover:bg-[#ececec] w-[82px] h-[38px] cursor-pointer"
+              onClick={async () => {
+                const result = await URLCopy()
+                alert(
+                  `${result ? '복사가 완료되었습니다.' : '복사가 실패하였습니다.'}`
+                )
+              }}
+            >
+              <GoLink className="h-[18px] w-[18px]" />
+              <div className="text-[12px] font-[500]">공유하기</div>
+            </button>
+          </div>
+          <div className="flex w-full h-[120px] gap-[40px] p-[20px] border-[1px] rounded-[12px] border-[#cecece] focus-within:border-[#6202E0]">
+            <CommentTextArea
+              textareaRef={textareaRef}
+              comments={Array.isArray(comments) ? comments : []}
+            />
+          </div>
+          <div className="flex flex-col w-full gap-[20px]">
+            <div className="flex items-center justify-between w-full">
+              <div className="flex items-center gap-[12px]">
+                <IoChatbubbleOutline className="w-[18px] h-[18px]" />
+                <div className="text-[#121212] text-[20px]">
+                  {Array.isArray(comments)
+                    ? `댓글 ${comments.length}개`
+                    : '댓글 0개'}
+                </div>
+              </div>
+              <div className="relative">
+                <button
+                  onClick={() => setSortDropdownOpen((prev) => !prev)}
+                  className="text-sm text-gray-700 hover:text-[#6202E0] flex items-center cursor-pointer"
+                >
+                  {selectedSort}
+                  <LuArrowUpDown className="w-4 h-4 ml-2" />
+                </button>
+                {sortDropdownOpen && (
+                  <div className="absolute top-[100%] right-0 mt-2 bg-white shadow-lg rounded-xl p-2 w-32 text-sm z-20">
+                    {['최신순', '오래된 순'].map((option) => (
+                      <div
+                        key={option}
+                        onClick={() => handleSort(option)}
+                        className={`cursor-pointer px-3 py-2 rounded-md text-center transition ${selectedSort === option ? 'bg-purple-100 text-[#6202E0] font-bold' : 'text-gray-700 hover:bg-gray-100'}`}
+                      >
+                        {option}
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </div>
+            </div>
+            <div className="flex flex-col gap-[17px] w-full">
+              {comments.map((commentData) => (
+                <Comment key={commentData.id} commentData={commentData} />
+              ))}
+            </div>
+            {hasNext && (
+              <div
+                ref={observerRef}
+                className="flex items-center justify-center w-full h-[40px]"
+              >
+                {isLoading && <CommentLoading />}
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  )
 }

--- a/src/pages/CommunityDetail.tsx
+++ b/src/pages/CommunityDetail.tsx
@@ -53,7 +53,6 @@ export default function CommunityDetail() {
 
   const [isLoading, setIsLoading] = useState(false)
   const [hasNext, setHasNext] = useState(true)
-  const [cursor, setCursor] = useState<number | null>(null)
 
   const {
     comments,
@@ -96,7 +95,6 @@ export default function CommunityDetail() {
 
   useEffect(() => {
     setComments([])
-    setCursor(0)
     setHasNext(true)
     fetchComments()
   }, [selectedSort])

--- a/src/pages/CommunityDetail.tsx
+++ b/src/pages/CommunityDetail.tsx
@@ -20,7 +20,6 @@ interface PostData {
   updated_at: string
 }
 
-
 import {
   useRef,
   useState,
@@ -46,7 +45,6 @@ import { IoChatbubbleOutline } from 'react-icons/io5'
 
 import { commentsMockData } from '@components/commnunityDetail/mockData'
 
-
 export default function CommunityDetail() {
   const { id } = useParams()
   const textareaRef = useRef(null)
@@ -54,10 +52,8 @@ export default function CommunityDetail() {
   const [isLike, setIsLike] = useState(false)
   const [likeNum, setLikeNum] = useState(2)
 
-
   const [isLoading, setIsLoading] = useState(false)
   const [hasNext, setHasNext] = useState(true)
-
 
   const {
     comments,
@@ -74,7 +70,6 @@ export default function CommunityDetail() {
       .then((res) => setPostData(res.data))
       .catch((err) => console.error('게시글 조회 실패:', err))
   }, [id])
-
 
   // 불러오기 함수
   const fetchComments = () => {
@@ -123,7 +118,6 @@ export default function CommunityDetail() {
     [isLoading, hasNext]
   )
 
-
   const handleSort = (option: SetStateAction<string>) => {
     setSelectedSort(option)
     setSortDropdownOpen((prev) => !prev)
@@ -134,12 +128,10 @@ export default function CommunityDetail() {
     setIsLike((prev) => !prev)
   }
 
-
   const handleCommentDel = (id: number) => {
     const delComments = comments.filter((comment) => comment.id !== id)
     setComments(delComments)
   }
-
 
   if (!postData) return <div className="text-center mt-36">로딩 중...</div>
 
@@ -160,7 +152,6 @@ export default function CommunityDetail() {
                     alt="작성자"
                     className="h-[48px] rounded-[50%]"
                   />
-
                 </div>
               </div>
             </div>
@@ -283,11 +274,14 @@ export default function CommunityDetail() {
                   </div>
                 )}
               </div>
-
             </div>
             <div className="flex flex-col gap-[17px] w-full">
               {comments.map((commentData) => (
-                <Comment key={commentData.id} commentData={commentData} />
+                <Comment
+                  key={commentData.id}
+                  commentData={commentData}
+                  handleCommentDel={handleCommentDel}
+                />
               ))}
             </div>
             {hasNext && (
@@ -298,7 +292,6 @@ export default function CommunityDetail() {
                 {isLoading && <CommentLoading />}
               </div>
             )}
-
           </div>
         </div>
       </div>


### PR DESCRIPTION


## ✅ PR 요약

- 관련 이슈 번호 : #88 
- 작업요약 : 커뮤니티 상세페이지 댓글 10개씩 무한 스크롤로 불러오기

<!-- ex: feat: 로그인 페이지 구현 -->

## 📋 상세 내용

<!-- 어떤 작업을 했는지 간단히 설명 -->

- 댓글 무한 스크롤로 10개씩 불러오기 기능 추가 로딩 지연 2초로 적용 되어 있으며, 추후 API 적용시 수정 예정

## 📸 스크린샷 (선택)
![댓글무한스크롤](https://github.com/user-attachments/assets/a6df440c-2bfb-4740-86ed-f54f6f2adfc9)




<!-- UI 변경 시 첨부 -->

## 📝 기타 참고사항

## 🧪 PR Check

<!-- 직접 테스트한 내용, 어떻게 동작을 확인했는지 작성 -->

- [x] 정상 동작 확인
- [x] UI 렌더링 확인
- [x] 기능 동작 확인
- [x] lint, type-check, build 오류 확인
