### PR TITLE
🐛 fix : 대분류 중분류 소분류 카테고리 하나의 카테고리 ui로 변경 및 저장 작업

### DIFF
--- a/src/components/CommunityPostAndEdit/CommunityPostAndEditForm.tsx
+++ b/src/components/CommunityPostAndEdit/CommunityPostAndEditForm.tsx
@@ -8,15 +8,11 @@ interface Props {
     initialData?: {
         title: string;
         mainCat: string;
-        subCat: string;
-        detailCat: string;
         markdown: string;
     };
     onSubmit: (data: {
         title: string;
         mainCat: string;
-        subCat: string;
-        detailCat: string;
         markdown: string;
     }) => void;
 }
@@ -24,16 +20,12 @@ interface Props {
 export default function CommunityPostAndEditForm({type, onSubmit, initialData}: Props) {
     const [title, setTitle] = useState(() => initialData?.title || '');
     const [mainCat, setMainCat] = useState(() => initialData?.mainCat || '');
-    const [subCat, setSubCat] = useState(() => initialData?.subCat || '');
-    const [detailCat, setDetailCat] = useState(() => initialData?.detailCat || '');
     const [markdown, setMarkdown] = useState(() => initialData?.markdown || '');
 
     useEffect(() => {
         if (type === 'edit' && initialData) {
             setTitle(initialData.title);
             setMainCat(initialData.mainCat);
-            setSubCat(initialData.subCat);
-            setDetailCat(initialData.detailCat);
             setMarkdown(initialData.markdown);
         }
     }, [initialData, type]);
@@ -41,8 +33,6 @@ export default function CommunityPostAndEditForm({type, onSubmit, initialData}: 
     const isFormValid =
         (title || '').trim() &&
         (mainCat || '').trim() &&
-        (subCat || '').trim() &&
-        (detailCat || '').trim() &&
         (markdown || '').trim();
 
     return (
@@ -52,10 +42,6 @@ export default function CommunityPostAndEditForm({type, onSubmit, initialData}: 
                 setTitle={setTitle}
                 mainCat={mainCat}
                 setMainCat={setMainCat}
-                subCat={subCat}
-                setSubCat={setSubCat}
-                detailCat={detailCat}
-                setDetailCat={setDetailCat}
             />
             <Content markdown={markdown} setMarkdown={setMarkdown}/>
             <SubmitButton
@@ -63,7 +49,7 @@ export default function CommunityPostAndEditForm({type, onSubmit, initialData}: 
                 disabled={!isFormValid}
                 onClick={() =>
                     isFormValid &&
-                    onSubmit({title, mainCat, subCat, detailCat, markdown})
+                    onSubmit({title, mainCat, markdown})
                 }
             />
         </>

--- a/src/components/CommunityPostAndEdit/PostFormHeader.tsx
+++ b/src/components/CommunityPostAndEdit/PostFormHeader.tsx
@@ -1,28 +1,13 @@
-import {getCategoryConfigs} from '@utils/getCategoryConfigs.ts';
-import {
-    mainCategories,
-    subCategories,
-    detailCategories,
-} from './data/categoryOptions';
+import { mainCategories } from './data/categoryOptions';
 
 interface Props {
     title: string;
     setTitle: (val: string) => void;
     mainCat: string;
     setMainCat: (val: string) => void;
-    subCat: string;
-    setSubCat: (val: string) => void;
-    detailCat: string;
-    setDetailCat: (val: string) => void;
 }
 
-export default function PostFormHeader(props: Props) {
-    const categories = getCategoryConfigs({
-        ...props,
-        mainOptions: mainCategories,
-        subOptions: subCategories,
-        detailOptions: detailCategories,
-    });
+export default function PostFormHeader({ title, setTitle, mainCat, setMainCat }: Props) {
 
     return (
         <header>
@@ -31,35 +16,26 @@ export default function PostFormHeader(props: Props) {
             </div>
 
             <div className="max-w-5xl mx-auto bg-white p-8 rounded-xl border border-gray-200 mt-6 gap-2.5">
-                <div className="grid grid-cols-3 gap-6 mb-6">
-                    {categories.map((cat) => (
-                        <div key={cat.key}>
-                            <select
-                                value={cat.value}
-                                onChange={(e) => cat.setValue(e.target.value)}
-                                disabled={cat.disabled}
-                                className={`
-                                    w-full px-3 py-2 border border-gray-300 rounded
-                                    focus:outline-none focus:ring-2 focus:ring-purple-500
-                                    ${cat.disabled ? 'bg-gray-100 text-gray-400 cursor-not-allowed' : 'cursor-pointer'}
-                                `}
-                            >
-                                <option className="cursor-pointer" value="" >{cat.label}</option>
-                                {cat.options.map((opt) => (
-                                    <option className="cursor-pointer" key={opt.value} value={opt.value}>
-                                        {opt.label}
-                                    </option>
-                                ))}
-                            </select>
-                        </div>
-                    ))}
+                <div className="mb-6">
+                    <select
+                        value={mainCat}
+                        onChange={(e) => setMainCat(e.target.value)}
+                        className="w-full px-3 py-2 border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-purple-500"
+                    >
+                        <option value="">대분류</option>
+                        {mainCategories.map((opt) => (
+                            <option key={opt.value} value={opt.value}>
+                                {opt.label}
+                            </option>
+                        ))}
+                    </select>
                 </div>
 
                 <div className="border border-purple-300 bg-purple-50 rounded-md px-4 py-3 shadow-sm">
                     <input
                         type="text"
-                        value={props.title}
-                        onChange={(e) => props.setTitle(e.target.value)}
+                        value={title}
+                        onChange={(e) => setTitle(e.target.value)}
                         placeholder="제목을 입력해 주세요"
                         className="w-full bg-transparent focus:outline-none text-gray-900"
                     />

--- a/src/components/CommunityPostAndEdit/data/categoryOptions.ts
+++ b/src/components/CommunityPostAndEdit/data/categoryOptions.ts
@@ -3,18 +3,13 @@ export interface SelectOption {
     label: string;
     value: string;
 }
-
+// const categories = ['전체','프론트엔드','백엔드','프로그래밍 언어','인프라','Python','React'];
 export const mainCategories: SelectOption[] = [
-    { id: 1, label: '프론트엔드', value: 'frontend' },
-    { id: 2, label: '백엔드', value: 'backend' },
-];
-
-export const subCategories: SelectOption[] = [
-    { id: 3, label: '프로그래밍 언어', value: 'lang' },
-    { id: 4, label: '인프라', value: 'infra' },
-];
-
-export const detailCategories: SelectOption[] = [
-    { id: 5, label: 'Python', value: 'python' },
-    { id: 6, label: 'React', value: 'react' },
+    { id: 1, label: '프론트엔드', value: '프론트엔드' },
+    { id: 2, label: '백엔드', value: '백엔드' },
+    { id: 3, label: '프로그래밍 언어', value: '프로그래밍 언어' },
+    { id: 4, label: '인프라', value: '인프라' },
+    { id: 5, label: 'Python', value: 'Python' },
+    { id: 6, label: 'React', value: 'React' },
+    { id: 7, label: '구인/협업', value: '구인/협업' },
 ];

--- a/src/pages/CommunityEdits.tsx
+++ b/src/pages/CommunityEdits.tsx
@@ -35,8 +35,6 @@ export default function CommunityEdits() {
     const [postData, setPostData] = useState<{
         title: string;
         mainCat: string;
-        subCat: string;
-        detailCat: string;
         markdown: string;
     } | null>(null);
     const [error, setError] = useState(false);
@@ -47,7 +45,7 @@ export default function CommunityEdits() {
                 .then(res => {
                     console.log("✅ 게시글 데이터:", res.data);
                     const raw = res.data;
-                    const [mainCat = '', subCat = '', detailCat = ''] = (raw.category?.name || '').split(' > ');
+                    const mainCat = raw.category?.name || '';
 
                     let markdownWithImages = raw.content;
 
@@ -62,8 +60,6 @@ export default function CommunityEdits() {
                     setPostData({
                         title: raw.title,
                         mainCat,
-                        subCat,
-                        detailCat,
                         markdown: markdownWithImages
                     });
                 })
@@ -77,14 +73,12 @@ export default function CommunityEdits() {
     const handleUpdate = async (updatedData: {
         title: string;
         mainCat: string;
-        subCat: string;
-        detailCat: string;
         markdown: string;
     }) => {
         if (!id) return;
 
         try {
-            const categoryName = `${updatedData.mainCat} > ${updatedData.subCat} > ${updatedData.detailCat}`;
+            const categoryName = `${updatedData.mainCat}`
 
             const imageRegex = /!\[.*?\]\((blob:[^)]+)\)/g;
             let contentWithBase64 = updatedData.markdown;
@@ -102,7 +96,7 @@ export default function CommunityEdits() {
             const payload = {
                 title: updatedData.title,
                 content: contentWithBase64,
-                category_id: 0, // put actual ID logic if needed
+                category_id: 0,
                 category_name: categoryName,
                 attachments: [],
                 images

--- a/src/pages/CommunityPost.tsx
+++ b/src/pages/CommunityPost.tsx
@@ -2,7 +2,7 @@ import axios from 'axios';
 import CommunityPostAndEditForm from "@components/CommunityPostAndEdit/CommunityPostAndEditForm.tsx";
 import {useNavigate} from "react-router";
 import {
-    detailCategories,
+    mainCategories,
 } from "../components/CommunityPostAndEdit/data/categoryOptions.ts";
 
 export default function CommunityPost() {
@@ -26,12 +26,10 @@ export default function CommunityPost() {
     const handleSubmit = async (data: {
         title: string;
         mainCat: string;
-        subCat: string;
-        detailCat: string;
         markdown: string;
     }) => {
         try {
-            const selectedDetail = detailCategories.find(cat => cat.value === data.detailCat);
+            const selectedDetail = mainCategories.find(cat => cat.value === data.mainCat);
             if (!selectedDetail) {
                 alert('카테고리 정보를 찾을 수 없습니다.');
                 return;
@@ -52,7 +50,7 @@ export default function CommunityPost() {
 
             const formData = {
                 category_id: selectedDetail.id,
-                category_name: `${data.mainCat} > ${data.subCat} > ${data.detailCat}`,
+                category_name: data.mainCat,
                 title: data.title,
                 content: contentWithPlaceholders,
                 attachments: [


### PR DESCRIPTION
## ✅ PR 요약

- 관련 이슈 번호 : #97 
- 작업요약 : 어떤 작업을 했는지 간단하게 적어주세요

<!-- ex: feat: 로그인 페이지 구현 -->

## 📋 상세 내용
3개의 카테고리 대분류 중분류 소분류의 3 개의 카테고리 UI 가 하나의 카테고리로 변경  


## 📸 스크린샷 (선택)

<img width="1466" alt="스크린샷 2025-07-04 오후 4 51 17" src="https://github.com/user-attachments/assets/70a25c8a-d85f-4446-8895-d6d4782eca79" />

<!-- UI 변경 시 첨부 -->

## 📝 기타 참고사항

## 🧪 PR Check

<!-- 직접 테스트한 내용, 어떻게 동작을 확인했는지 작성 -->

- [ ] 정상 동작 확인
- [ ] UI 렌더링 확인
- [ ] 기능 동작 확인
- [ ] lint, type-check, build 오류 확인
