### PR TITLE
✨ feat: 탈퇴 회원 이메일 인증 UI 구현

### DIFF
--- a/src/components/common/Button.tsx
+++ b/src/components/common/Button.tsx
@@ -25,7 +25,7 @@ const Button: React.FC<ButtonProps> = ({ fullWidth = true, className = '', child
   return (
     <button
       {...props}
-      className={`h-[48px] rounded text-[14px] flex items-center justify-center cursor-pointer
+      className={`h-[48px] rounded text-[14px] flex items-center justify-center cursor-pointer"
         ${fullWidth ? 'w-full' : ''} ${className}`}
     >
       {children}

--- a/src/components/login/LoginForm.tsx
+++ b/src/components/login/LoginForm.tsx
@@ -15,6 +15,7 @@ import { useUserInfo } from '@store/userInfoStore'
 import { useNavigate } from 'react-router'
 
 import RestoreUserInfoModal from '@components/modals/RestoreUserModal/RestoreUserInfoModal'
+import RestoreUserForm from '@components/modals/RestoreUserModal/RestoreUserForm'
 
 const LoginForm = () => {
   const [openFindIdModal, setOpenFindIdModal] = useState(false) // 아이디 찾기 모달
@@ -26,6 +27,7 @@ const LoginForm = () => {
   const { setUserInfo } = useUserInfo()
 
   const [showRestoreModal, setShowRestoreModal] = useState(false);
+  const [showRestoreForm, setShowRestoreForm] = useState(false);
 
   const navigate = useNavigate()
 
@@ -93,12 +95,23 @@ const LoginForm = () => {
           showFindIdSuccess={showFindIdSuccess}
           setShowFindIdSuccess={setShowFindIdSuccess}
         />
-        {showRestoreModal && (
+        {showRestoreModal && !showRestoreForm && (
           <RestoreUserInfoModal
             onClose={() => setShowRestoreModal(false)}
             onNext={() => {
+              setShowRestoreForm(true);    
+            }}
+          />
+        )}
+        {showRestoreForm && (
+          <RestoreUserForm
+            onVerified={() => {
+              setShowRestoreForm(false);
               setShowRestoreModal(false);
-              // 이후 복구 단계로 이동 처리 (필요 시 추가)
+            }}
+            onClose={() => {
+              setShowRestoreForm(false);
+              setShowRestoreModal(false);
             }}
           />
         )}

--- a/src/components/login/LoginInputs.tsx
+++ b/src/components/login/LoginInputs.tsx
@@ -74,7 +74,7 @@ const LoginInputs = ({
     {/* 로그인 버튼 */}
     <Button
       disabled={!email || !password}
-      className={`w-[348px] h-[52px] font-semibold rounded mt-2 
+      className={`w-[348px] h-[52px] font-semibold rounded mt-2 cursor-pointer
         ${email && password ? 'bg-[#6201E0] text-white' : 'bg-[#ECECEC] text-[#BDBDBD]'}`}
       onClick={login}
     >

--- a/src/components/modals/RestoreUserModal/RestoreUserForm.tsx
+++ b/src/components/modals/RestoreUserModal/RestoreUserForm.tsx
@@ -1,0 +1,83 @@
+import ModalWrapper from '@components/common/ModalWrapper';
+import ModalHeader from '@components/common/ModalHeader';
+import CloseButton from '@components/common/CloseButton';
+import Input from '@components/common/Input';
+import Button from '@components/common/Button';
+import { GoSync } from 'react-icons/go';
+import { useState } from 'react';
+
+interface Props {
+  onVerified: () => void;
+  onClose: () => void;
+}
+
+const RestoreUserForm = ({ onVerified, onClose }: Props) => {
+  const [email, setEmail] = useState('');
+  const [code, setCode] = useState('');
+
+  return (
+    <ModalWrapper className="w-[396px] max-w-full relative">
+    <CloseButton onClick={onClose} className="top-[24px]" />
+    <div className="mb-[40px]">
+      <ModalHeader
+        icon={<GoSync size={16} />}
+        title="계정 다시 사용하기"
+        noMarginBottom 
+      />
+      <p className="mt-[10px] text-[14px] text-[#4d4d4d]">입력하신 이메일로 인증번호를 보내드릴게요.</p>
+     </div>
+      {/* 이메일 입력 + 인증코드 전송 버튼 */}
+      <div className="flex flex-col gap-[8px]">
+      <label className="text-[16px] text-[#121212] font-normal text-left block">
+        이메일 <span className="text-[#EC0037]">*</span>
+      </label>
+      <div className="flex gap-[8px]">
+        <Input
+          placeholder="가입한 이메일을 입력해 주세요."
+          value={email}
+          fullWidth={false}
+          noMarginBottom={false}
+          onChange={(e) => setEmail(e.target.value)}
+          className="flex-1 w-[201px]"
+        />
+        <Button
+          type="button"
+          fullWidth={false}
+          className="w-[140px] h-[48px] text-[#1E1E1E] bg-[#F5F5F5] border border-[#CECECE] cursor-pointer"
+        >
+          인증코드전송
+        </Button>
+      </div>
+    </div>
+
+      {/* 인증번호 입력 + 인증확인 버튼 */}
+      <div className="flex gap-[8px] mb-[24px]">
+        <Input
+          placeholder="인증번호 6자리를 입력해주세요"
+          value={code}
+          fullWidth={false}
+          onChange={(e) => setCode(e.target.value)}
+          className="flex-1 w-[201px]"
+          maxLength={6}
+        />
+        <Button 
+          type="button" 
+          fullWidth={false}
+          className="w-[140px] text-[#1E1E1E] bg-[#F5F5F5] border border-[#CECECE] cursor-pointer">
+          인증코드확인
+        </Button>
+      </div>
+
+      {/* 확인 버튼 */}
+      <Button
+        type="button"
+        className="w-full h-[48px] bg-[#6201E0] text-white rounded cursor-pointer"
+        onClick={onVerified}
+      >
+        확인
+      </Button>
+    </ModalWrapper>
+  );
+};
+
+export default RestoreUserForm;

--- a/src/components/modals/RestoreUserModal/RestoreUserInfoModal.tsx
+++ b/src/components/modals/RestoreUserModal/RestoreUserInfoModal.tsx
@@ -2,11 +2,13 @@ import { ModalWrapper, ModalHeader, Button } from "@components/common";
 import { CiFaceMeh } from "react-icons/ci";
 import CloseButton from "@components/common/CloseButton";
 
+
 interface Props {
     onNext: () => void; // "계정 다시 사용하기" 클릭 시 처리
     onClose: () => void; // 닫기 버튼
   }
   
+
   const RestoreUserInfoModal = ({ onNext, onClose }: Props) => {
     return (
       <ModalWrapper className="w-[396px] max-w-full h-[278px]">
@@ -31,7 +33,7 @@ interface Props {
           {/* 버튼 */}
           <Button
             onClick={onNext}
-            className="w-full h-[48px] bg-[#6201E0] text-white rounded mt-[40px]"
+            className="w-full h-[48px] bg-[#6201E0] text-white rounded mt-[40px] cursor-pointer"
           >
             계정 다시 사용하기
           </Button>


### PR DESCRIPTION
탈퇴 회원이 로그인 시 이메일 인증을 통해 계정 복구할 수 있도록 UI 구성

## ✅ PR 요약

- 관련 이슈 번호 : 
- 작업요약 : 탈퇴 회원이 로그인 시 이메일 인증을 통해 계정 복구할 수 있도록 UI 구성

<!-- ex: feat: 로그인 페이지 구현 -->

## 📋 상세 내용

<!-- 어떤 작업을 했는지 간단히 설명 -->

- 탈퇴 회원 로그인 시 모달 분기 처리
- RestoreUserInfoModal → 이메일 인증 폼으로 전환 기능 구현
- RestoreUserForm 레이아웃 및 버튼/인풋 UI 구성 완료
- 공통 컴포넌트(Button, Input, ModalWrapper, ModalHeader, CloseButton) 활용

## 📸 스크린샷 (선택)
<img width="1687" alt="스크린샷 2025-07-04 오후 5 01 30" src="https://github.com/user-attachments/assets/2d0d7726-f160-45f5-91f6-7cc940b5f2b2" />

<!-- UI 변경 시 첨부 -->

## 📝 기타 참고사항

## 🧪 PR Check

<!-- 직접 테스트한 내용, 어떻게 동작을 확인했는지 작성 -->

- [ ] 정상 동작 확인
- [ ] UI 렌더링 확인
- [ ] 기능 동작 확인
- [ ] lint, type-check, build 오류 확인
