### PR TITLE
✨ feat     : 탈퇴 회원 복구 플로우 UI 구현 및 성공 팝업 연동

### DIFF
--- a/src/components/common/SuccessPopup.tsx
+++ b/src/components/common/SuccessPopup.tsx
@@ -18,6 +18,7 @@ import { FaCheck } from 'react-icons/fa6';
 interface SuccessPopupProps {
   title: string; // 타이틀 (굵은 텍스트)
   message: string; // 메시지 내용
+  onConfirm: () => void;
 }
 
 const SuccessPopup = ({ title, message }: SuccessPopupProps) => {

--- a/src/components/common/Toast.tsx
+++ b/src/components/common/Toast.tsx
@@ -13,12 +13,13 @@ import { FaCheck } from 'react-icons/fa6';
 
 interface ToastProps {
   message: string; // 토스트에 표시할 텍스트
+  classname?: string;
 }
 
-const Toast: React.FC<ToastProps> = ({ message }) => {
+const Toast: React.FC<ToastProps> = ({ message, classname = '' }) => {
   return (
-    <div className="fixed top-[160px] left-1/2 -translate-x-1/2 w-auto max-w-[360px] h-[48px] bg-[#FAFAFA] 
-        border border-[#ECECEC] rounded flex items-center px-[16px] shadow z-[9999]">
+    <div className={`fixed top-[170px] left-1/2 -translate-x-1/2 w-auto max-w-[360px] h-[48px] 
+        bg-[#FAFAFA] border border-[#ECECEC] rounded flex items-center px-[16px] shadow z-[9999] ${classname}`}>
       <div className="w-[20px] h-[20px] bg-[#14C786] rounded-full flex items-center justify-center mr-[12px]">
         <FaCheck className="text-white text-[12px]" />
       </div>

--- a/src/components/login/LoginForm.tsx
+++ b/src/components/login/LoginForm.tsx
@@ -14,8 +14,7 @@ import axios from 'axios'
 import { useUserInfo } from '@store/userInfoStore'
 import { useNavigate } from 'react-router'
 
-import RestoreUserInfoModal from '@components/modals/RestoreUserModal/RestoreUserInfoModal'
-import RestoreUserForm from '@components/modals/RestoreUserModal/RestoreUserForm'
+import RestoreUserModal from '@components/modals/RestoreUserModal/RestoreUserModal'
 
 const LoginForm = () => {
   const [openFindIdModal, setOpenFindIdModal] = useState(false) // 아이디 찾기 모달
@@ -95,27 +94,10 @@ const LoginForm = () => {
           showFindIdSuccess={showFindIdSuccess}
           setShowFindIdSuccess={setShowFindIdSuccess}
         />
-        {showRestoreModal && !showRestoreForm && (
-          <RestoreUserInfoModal
-            onClose={() => setShowRestoreModal(false)}
-            onNext={() => {
-              setShowRestoreForm(true);    
-            }}
-          />
-        )}
-        {showRestoreForm && (
-          <RestoreUserForm
-            onVerified={() => {
-              setShowRestoreForm(false);
-              setShowRestoreModal(false);
-            }}
-            onClose={() => {
-              setShowRestoreForm(false);
-              setShowRestoreModal(false);
-            }}
-          />
-        )}
       </div>
+      {showRestoreModal && (
+      <RestoreUserModal onClose={() => setShowRestoreModal(false)} />
+    )}
     </div>
   )
 }

--- a/src/components/login/LoginForm.tsx
+++ b/src/components/login/LoginForm.tsx
@@ -26,7 +26,6 @@ const LoginForm = () => {
   const { setUserInfo } = useUserInfo()
 
   const [showRestoreModal, setShowRestoreModal] = useState(false);
-  const [showRestoreForm, setShowRestoreForm] = useState(false);
 
   const navigate = useNavigate()
 

--- a/src/components/modals/ResetPwModal/ResetPwModal.tsx
+++ b/src/components/modals/ResetPwModal/ResetPwModal.tsx
@@ -42,6 +42,7 @@ const ResetPwModal = ({ onClose }: { onClose: () => void }) => {
         <SuccessPopup
           title="비밀번호 변경 완료!"
           message="잠시 후 로그인 페이지로 이동합니다."
+          onConfirm={onClose}
         />
       ) : (
         // 입력 폼 모드

--- a/src/components/modals/RestoreUserModal/RestoreUserForm.tsx
+++ b/src/components/modals/RestoreUserModal/RestoreUserForm.tsx
@@ -10,11 +10,11 @@ import { formatTime } from '@utils/formatTime';
 import { SuccessPopup } from '@components/common';
 
 interface Props {
-  onVerified: () => void;
+
   onClose: () => void;
 }
 
-const RestoreUserForm = ({ onVerified, onClose }: Props) => {
+const RestoreUserForm = ({ onClose }: Props) => {
   const [email, setEmail] = useState('');
   const [code, setCode] = useState('');
   const [showToast, setShowToast] = useState(false);

--- a/src/components/modals/RestoreUserModal/RestoreUserForm.tsx
+++ b/src/components/modals/RestoreUserModal/RestoreUserForm.tsx
@@ -1,10 +1,13 @@
-import ModalWrapper from '@components/common/ModalWrapper';
 import ModalHeader from '@components/common/ModalHeader';
 import CloseButton from '@components/common/CloseButton';
 import Input from '@components/common/Input';
 import Button from '@components/common/Button';
-import { GoSync } from 'react-icons/go';
+import Toast from '@components/common/Toast';
+import { GrPowerReset } from "react-icons/gr";
 import { useState } from 'react';
+import useCountdown from '@hooks/useCountdown';
+import { formatTime } from '@utils/formatTime';
+import { SuccessPopup } from '@components/common';
 
 interface Props {
   onVerified: () => void;
@@ -14,56 +17,90 @@ interface Props {
 const RestoreUserForm = ({ onVerified, onClose }: Props) => {
   const [email, setEmail] = useState('');
   const [code, setCode] = useState('');
+  const [showToast, setShowToast] = useState(false);
+  const [codeInputVisible, setCodeInputVisible] = useState(false);
+  const [showSuccessPopup, setShowSuccessPopup] = useState(false);
+
+  const { timeLeft, start } = useCountdown({
+    duration: 300,
+    onExpire: () => setCodeInputVisible(false),
+  });
+
+  const handleSendCode = () => {
+    if (!email.trim()) return;
+    setShowToast(true);
+    setCodeInputVisible(true);
+    start();
+    setTimeout(() => setShowToast(false), 3000);
+  };
 
   return (
-    <ModalWrapper className="w-[396px] max-w-full relative">
-    <CloseButton onClick={onClose} className="top-[24px]" />
-    <div className="mb-[40px]">
-      <ModalHeader
-        icon={<GoSync size={16} />}
-        title="계정 다시 사용하기"
-        noMarginBottom 
-      />
-      <p className="mt-[10px] text-[14px] text-[#4d4d4d]">입력하신 이메일로 인증번호를 보내드릴게요.</p>
-     </div>
-      {/* 이메일 입력 + 인증코드 전송 버튼 */}
-      <div className="flex flex-col gap-[8px]">
-      <label className="text-[16px] text-[#121212] font-normal text-left block">
-        이메일 <span className="text-[#EC0037]">*</span>
-      </label>
-      <div className="flex gap-[8px]">
-        <Input
-          placeholder="가입한 이메일을 입력해 주세요."
-          value={email}
-          fullWidth={false}
-          noMarginBottom={false}
-          onChange={(e) => setEmail(e.target.value)}
-          className="flex-1 w-[201px]"
+    <div>
+      {showToast && <Toast message="전송 완료! 이메일을 확인해주세요." 
+      classname="mt-[20px]"/>}
+      <CloseButton onClick={onClose} className="top-[24px]" />
+      <div className="mb-[40px]">
+        <ModalHeader
+          icon={<GrPowerReset size={16} />}
+          title="계정 다시 사용하기"
+          noMarginBottom
         />
+        <p className="mt-[10px] text-[14px] text-[#4d4d4d] text-center">
+          입력하신 이메일로 인증번호를 보내드릴게요.
+        </p>
+      </div>
+
+      {/* 이메일 입력 */}
+      <div className="flex flex-col gap-[8px]">
+        <label className="text-[16px] text-[#121212] font-normal text-left block">
+          이메일 <span className="text-[#EC0037]">*</span>
+        </label>
+        <div className="flex gap-[8px]">
+          <Input
+            placeholder="가입한 이메일을 입력해 주세요."
+            value={email}
+            fullWidth={false}
+            noMarginBottom={false}
+            onChange={(e) => setEmail(e.target.value)}
+            className="flex-1 w-[228px]"
+          />
+          <Button
+            type="button"
+            fullWidth={false}
+            onClick={handleSendCode}
+            className="w-[112px] h-[48px] text-[#1E1E1E] bg-[#F5F5F5] border border-[#CECECE] cursor-pointer"
+          >
+            인증코드전송
+          </Button>
+        </div>
+      </div>
+
+      {/* 인증번호 입력 */}
+      <div className="flex gap-[8px] mb-[24px]">
+        <div className="relative w-[228px]">
+          <Input
+            placeholder={
+              codeInputVisible
+                ? '인증번호를 입력해주세요'
+                : '인증번호 6자리를 입력해주세요'
+            }
+            value={code}
+            fullWidth={false}
+            onChange={(e) => setCode(e.target.value)}
+            className="w-full pr-[60px]"
+            maxLength={6}
+          />
+          {codeInputVisible && (
+            <span className="absolute right-[12px] top-[24px] -translate-y-1/2 text-[#EC0037] text-[12px]">
+              {formatTime(timeLeft)}
+            </span>
+          )}
+        </div>
         <Button
           type="button"
           fullWidth={false}
-          className="w-[140px] h-[48px] text-[#1E1E1E] bg-[#F5F5F5] border border-[#CECECE] cursor-pointer"
+          className="w-[112px] text-[#1E1E1E] bg-[#F5F5F5] border border-[#CECECE] cursor-pointer"
         >
-          인증코드전송
-        </Button>
-      </div>
-    </div>
-
-      {/* 인증번호 입력 + 인증확인 버튼 */}
-      <div className="flex gap-[8px] mb-[24px]">
-        <Input
-          placeholder="인증번호 6자리를 입력해주세요"
-          value={code}
-          fullWidth={false}
-          onChange={(e) => setCode(e.target.value)}
-          className="flex-1 w-[201px]"
-          maxLength={6}
-        />
-        <Button 
-          type="button" 
-          fullWidth={false}
-          className="w-[140px] text-[#1E1E1E] bg-[#F5F5F5] border border-[#CECECE] cursor-pointer">
           인증코드확인
         </Button>
       </div>
@@ -72,11 +109,20 @@ const RestoreUserForm = ({ onVerified, onClose }: Props) => {
       <Button
         type="button"
         className="w-full h-[48px] bg-[#6201E0] text-white rounded cursor-pointer"
-        onClick={onVerified}
+        onClick={() => setShowSuccessPopup(true)}
       >
         확인
       </Button>
-    </ModalWrapper>
+      {showSuccessPopup && (
+        <div className="fixed inset-0 flex justify-center items-center z-50 bg-black/50">
+          <SuccessPopup
+            title="계정 복구 완료!"
+            message="이제 다시 로그인하실 수 있어요."
+            onConfirm={onClose}
+          />
+        </div>
+      )}
+    </div>
   );
 };
 

--- a/src/components/modals/RestoreUserModal/RestoreUserInfoModal.tsx
+++ b/src/components/modals/RestoreUserModal/RestoreUserInfoModal.tsx
@@ -1,4 +1,4 @@
-import { ModalWrapper, ModalHeader, Button } from "@components/common";
+import { ModalHeader, Button } from "@components/common";
 import { CiFaceMeh } from "react-icons/ci";
 import CloseButton from "@components/common/CloseButton";
 
@@ -11,7 +11,7 @@ interface Props {
 
   const RestoreUserInfoModal = ({ onNext, onClose }: Props) => {
     return (
-      <ModalWrapper className="w-[396px] max-w-full h-[278px]">
+      <div className="w-[396px] max-w-full">
         {/* 닫기 버튼 */}
         <CloseButton onClick={onClose} className="top-[24px]"/>
 
@@ -33,12 +33,12 @@ interface Props {
           {/* 버튼 */}
           <Button
             onClick={onNext}
-            className="w-full h-[48px] bg-[#6201E0] text-white rounded mt-[40px] cursor-pointer"
+            className="w-full h-[48px] bg-[#6201E0] text-white rounded mt-[24px] cursor-pointer"
           >
             계정 다시 사용하기
           </Button>
         </div>
-      </ModalWrapper>
+      </div>
     );
   };
   

--- a/src/components/modals/RestoreUserModal/RestoreUserModal.tsx
+++ b/src/components/modals/RestoreUserModal/RestoreUserModal.tsx
@@ -27,7 +27,6 @@ const RestoreUserModal = ({ onClose }: Props) => {
 
       {step === 'form' && (
         <RestoreUserForm
-          onVerified={() => setStep('success')}
           onClose={handleClose}
         />
       )}

--- a/src/components/modals/RestoreUserModal/RestoreUserModal.tsx
+++ b/src/components/modals/RestoreUserModal/RestoreUserModal.tsx
@@ -1,0 +1,46 @@
+import ModalWrapper from '@components/common/ModalWrapper';
+import RestoreUserInfoModal from './RestoreUserInfoModal';
+import RestoreUserForm from './RestoreUserForm';
+import SuccessPopup from '@components/common/SuccessPopup';
+import { useState } from 'react';
+
+interface Props {
+  onClose: () => void;
+}
+
+const RestoreUserModal = ({ onClose }: Props) => {
+  const [step, setStep] = useState<'info' | 'form' | 'success'>('info');
+
+  const handleClose = () => {
+    setStep('info');
+    onClose();
+  };
+
+  return (
+    <ModalWrapper className="w-[396px] max-w-full relative">
+      {step === 'info' && (
+        <RestoreUserInfoModal
+          onNext={() => setStep('form')}
+          onClose={handleClose}
+        />
+      )}
+
+      {step === 'form' && (
+        <RestoreUserForm
+          onVerified={() => setStep('success')}
+          onClose={handleClose}
+        />
+      )}
+
+      {step === 'success' && (
+        <SuccessPopup
+          title="계정 복구 완료!"
+          message="이제 다시 로그인하실 수 있어요."
+          onConfirm={handleClose}
+        />
+      )}
+    </ModalWrapper>
+  );
+};
+
+export default RestoreUserModal;


### PR DESCRIPTION
## ✅ PR 요약

- 관련 이슈 번호 : 
- 작업요약 : 탈퇴 회원 복구를 위한 모달 UI 및 성공 팝업 단계별 전환 로직 구현

<!-- ex: feat: 로그인 페이지 구현 -->

## 📋 상세 내용

<!-- 어떤 작업을 했는지 간단히 설명 -->

- 탈퇴 회원 로그인 시 복구 모달(RestoreUserModal) 동작
- 모달 내부 단계별 UI 구성 (RestoreUserInfoModal → RestoreUserForm)
- 인증번호 전송 버튼 클릭 시:
- - 토스트 메시지 출력
- - 인증번호 입력창 placeholder 변경 및 타이머 표시
- 인증번호 확인 후 확인 버튼 클릭 시 SuccessPopup 출력
- RestoreUserModal에서 모든 상태(step / 완료) 관리
- 디자인 가이드에 맞춘 UI 정렬, 여백 및 스타일 유지



## 📸 스크린샷 (선택)

<!-- UI 변경 시 첨부 -->

## 📝 기타 참고사항

## 🧪 PR Check

<!-- 직접 테스트한 내용, 어떻게 동작을 확인했는지 작성 -->

- [x] 정상 동작 확인
- [x] UI 렌더링 확인
- [x] 기능 동작 확인
- [x] lint, type-check, build 오류 확인
