### PR TITLE
✨ feat: 계정 복구 완료 SuccessPopup 모달 분리 및 단독 노출 처리

### DIFF
--- a/src/components/modals/RestoreUserModal/RestoreUserForm.tsx
+++ b/src/components/modals/RestoreUserModal/RestoreUserForm.tsx
@@ -7,19 +7,18 @@ import { GrPowerReset } from "react-icons/gr";
 import { useState } from 'react';
 import useCountdown from '@hooks/useCountdown';
 import { formatTime } from '@utils/formatTime';
-import { SuccessPopup } from '@components/common';
 
 interface Props {
 
   onClose: () => void;
+  onVerified: () => void;
 }
 
-const RestoreUserForm = ({ onClose }: Props) => {
+const RestoreUserForm = ({ onVerified, onClose }: Props) => {
   const [email, setEmail] = useState('');
   const [code, setCode] = useState('');
   const [showToast, setShowToast] = useState(false);
   const [codeInputVisible, setCodeInputVisible] = useState(false);
-  const [showSuccessPopup, setShowSuccessPopup] = useState(false);
 
   const { timeLeft, start } = useCountdown({
     duration: 300,
@@ -109,19 +108,10 @@ const RestoreUserForm = ({ onClose }: Props) => {
       <Button
         type="button"
         className="w-full h-[48px] bg-[#6201E0] text-white rounded cursor-pointer"
-        onClick={() => setShowSuccessPopup(true)}
+        onClick={onVerified}
       >
         확인
       </Button>
-      {showSuccessPopup && (
-        <div className="fixed inset-0 flex justify-center items-center z-50 bg-black/50">
-          <SuccessPopup
-            title="계정 복구 완료!"
-            message="이제 다시 로그인하실 수 있어요."
-            onConfirm={onClose}
-          />
-        </div>
-      )}
     </div>
   );
 };

--- a/src/components/modals/RestoreUserModal/RestoreUserModal.tsx
+++ b/src/components/modals/RestoreUserModal/RestoreUserModal.tsx
@@ -9,12 +9,34 @@ interface Props {
 }
 
 const RestoreUserModal = ({ onClose }: Props) => {
-  const [step, setStep] = useState<'info' | 'form' | 'success'>('info');
+  const [step, setStep] = useState<'info' | 'form'>('info');
+  const [showSuccess, setShowSuccess] = useState(false);
 
   const handleClose = () => {
     setStep('info');
+    setShowSuccess(false);
     onClose();
   };
+
+  const handleVerify = () => {
+    setShowSuccess(true);
+    setTimeout(() => {
+      setShowSuccess(false);
+      handleClose();
+    }, 10000);
+  };
+
+  if (showSuccess) {
+    return (
+      <div className="fixed inset-0 z-50 bg-[rgba(18,18,18,0.6)] flex items-center justify-center">
+        <SuccessPopup
+          title="계정 복구 완료!"
+          message="잠시 후 로그인 페이지로 이동합니다."
+          onConfirm={handleClose}
+        />
+      </div>
+    );
+  }
 
   return (
     <ModalWrapper className="w-[396px] max-w-full relative">
@@ -27,15 +49,8 @@ const RestoreUserModal = ({ onClose }: Props) => {
 
       {step === 'form' && (
         <RestoreUserForm
+          onVerified={handleVerify}
           onClose={handleClose}
-        />
-      )}
-
-      {step === 'success' && (
-        <SuccessPopup
-          title="계정 복구 완료!"
-          message="이제 다시 로그인하실 수 있어요."
-          onConfirm={handleClose}
         />
       )}
     </ModalWrapper>


### PR DESCRIPTION
## ✅ PR 요약

- 관련 이슈 번호 : 
- 작업요약 : 

<!-- ex: feat: 로그인 페이지 구현 -->

## 📋 상세 내용

<!-- 어떤 작업을 했는지 간단히 설명 -->

- RestoreUserModal에서 SuccessPopup을 ModalWrapper 바깥으로 분리하여 팝업 단독 노출되도록 수정
- 배경 dim 및 위치 충돌 문제 해결
- 확인 버튼 클릭 시 10초 후 자동 닫힘 로직 포함

## 📸 스크린샷 (선택)
<img width="1710" alt="스크린샷 2025-07-07 오후 3 05 47" src="https://github.com/user-attachments/assets/f5b4521c-6678-475a-b3d4-bfe90a0cd1d5" />

<!-- UI 변경 시 첨부 -->

## 📝 기타 참고사항

## 🧪 PR Check

<!-- 직접 테스트한 내용, 어떻게 동작을 확인했는지 작성 -->

- [x] 정상 동작 확인
- [x] UI 렌더링 확인
- [x] 기능 동작 확인
- [x] lint, type-check, build 오류 확인
