### PR TITLE
✨ feat: 드롭다운 상태 관리 및 선택 조건 로직 적용

### DIFF
--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -92,6 +92,8 @@ export default function NavBar() {
                       setUserInfo(null)
                       setIsDropdownOpen(false)
                       localStorage.removeItem('userData')
+                    } else {
+                      throw new Error('Error')
                     }
                   }}
                   className="px-3 py-2 text-left transition cursor-pointer 

--- a/src/components/modals/RegisterStudentModal/ClassSelect.tsx
+++ b/src/components/modals/RegisterStudentModal/ClassSelect.tsx
@@ -1,28 +1,51 @@
-import { useState } from 'react'
+import { IoCheckmark } from 'react-icons/io5'
 
 interface ClassSelectProps {
   selected: string
   onChange: (value: string) => void
+  isOpen: boolean
+  onOpen: () => void
+  onClose: () => void
+  disabled?: boolean
 }
 
-const classList = ['1기', '2기', '3기', '4기', '5기', '6기', '7기', '8기', '9기', '10기', '11기', '12기']
+const classList = [
+  '1기', '2기', '3기', '4기', '5기', '6기',
+  '7기', '8기', '9기', '10기', '11기', '12기'
+]
 
-export default function ClassSelect({ selected, onChange }: ClassSelectProps) {
-  const [isOpen, setIsOpen] = useState(false)
+export default function ClassSelect({
+  selected,
+  onChange,
+  isOpen,
+  onOpen,
+  onClose,
+  disabled = false,
+}: ClassSelectProps) {
+  const containerClassName = [
+    'border border-[#BDBDBD] h-[48px] px-4 rounded flex items-center justify-between',
+    disabled ? 'bg-[#F5F5F5] cursor-not-allowed' : 'cursor-pointer',
+  ].join(' ')
+
+  const getItemClassName = (isSelected: boolean) =>
+    [
+      'w-[309px] h-[48px] px-[12px] py-2 ml-[12px] mt-[5px]',
+      'flex justify-between items-center text-[14px] cursor-pointer',
+      isSelected ? 'text-[#6201E0] font-semibold' : 'text-[#121212]',
+      'hover:bg-[#EFE6FC]',
+    ].join(' ')
 
   return (
     <div className="mb-4 relative w-full">
       <div
-        className="border border-[#BDBDBD] h-[48px] px-4 rounded flex items-center justify-between cursor-pointer"
-        onClick={() => setIsOpen((prev) => !prev)}
+        className={containerClassName}
+        onClick={() => (isOpen ? onClose() : onOpen())}
       >
-        <span className="text-[14px] text-[#bdbdbd]">
+        <span className={`text-[14px] ${selected ? 'text-[#121212]' : 'text-[#BDBDBD]'}`}>
           {selected || '기수를 선택하세요'}
         </span>
         <svg
-          className={`w-[16px] h-[16px] transition-transform ${
-            isOpen ? 'rotate-180' : ''
-          }`}
+          className={`w-[16px] h-[16px] transition-transform ${isOpen ? 'rotate-180' : ''}`}
           fill="none"
           stroke="currentColor"
           viewBox="0 0 24 24"
@@ -30,20 +53,25 @@ export default function ClassSelect({ selected, onChange }: ClassSelectProps) {
           <path strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
         </svg>
       </div>
-      {isOpen && (
-        <div className="absolute z-10 bg-white border border-[#BDBDBD] rounded mt-1 w-full shadow-md">
-          {classList.map((cls) => (
-            <div
-              key={cls}
-              onClick={() => {
-                onChange(cls)
-                setIsOpen(false)
-              }}
-              className="px-4 py-2 text-[14px] hover:bg-purple-100 hover:text-[#6201E0] cursor-pointer"
-            >
-              {cls}
-            </div>
-          ))}
+
+      {isOpen && !disabled && (
+        <div className="absolute z-10 bg-white border border-[#BDBDBD] rounded mt-1 w-full shadow-md max-h-[200px] overflow-y-auto">
+          {classList.map((cls) => {
+            const isSelected = selected === cls
+            return (
+              <div
+                key={cls}
+                onClick={() => {
+                  onChange(cls)
+                  onClose()
+                }}
+                className={getItemClassName(isSelected)}
+              >
+                <span>{cls}</span>
+                {isSelected && <IoCheckmark size={16} />}
+              </div>
+            )
+          })}
         </div>
       )}
     </div>

--- a/src/components/modals/RegisterStudentModal/CourseSelect.tsx
+++ b/src/components/modals/RegisterStudentModal/CourseSelect.tsx
@@ -1,29 +1,33 @@
-import { useState } from 'react'
 import { IoCheckmark } from 'react-icons/io5'
 
 interface CourseSelectProps {
   selected: string
   onChange: (value: string) => void
+  isOpen: boolean
+  onOpen: () => void
+  onClose: () => void
 }
 
-const courseList = ['웹 개발 초격차 프론트엔드 부트캠프', '웹 개발 초격차 백엔드 부트캠프', 'IT 스타트업 실무형 사업 개발자(BD) 부트캠프', '스타트업 맞춤형 프로덕트 디자이너', 'IT스타트업 실무형 풀스택 웹 개발 부트캠프']
+const courseList = [
+  '웹 개발 초격차 프론트엔드 부트캠프',
+  '웹 개발 초격차 백엔드 부트캠프',
+  'IT 스타트업 실무형 사업 개발자(BD) 부트캠프',
+  '스타트업 맞춤형 프로덕트 디자이너',
+  'IT스타트업 실무형 풀스택 웹 개발 부트캠프'
+]
 
-export default function CourseSelect({ selected, onChange }: CourseSelectProps) {
-  const [isOpen, setIsOpen] = useState(false)
-
+export default function CourseSelect({ selected, onChange, isOpen, onOpen, onClose }: CourseSelectProps) {
   return (
     <div className="mb-4 relative w-full">
       <div
         className="border border-[#BDBDBD] h-[48px] px-4 rounded flex items-center justify-between cursor-pointer"
-        onClick={() => setIsOpen((prev) => !prev)}
+        onClick={() => (isOpen ? onClose() : onOpen())}
       >
-        <span className="text-[14px] text-[#bdbdbd]">
+        <span className={`text-[14px] ${selected ? 'text-[#121212]' : 'text-[#bdbdbd]'}`}>
           {selected || '수강중인 과정을 선택해 주세요.'}
         </span>
         <svg
-          className={`w-[16px] h-[16px] transition-transform ${
-            isOpen ? 'rotate-180' : ''
-          }`}
+          className={`w-[16px] h-[16px] transition-transform ${isOpen ? 'rotate-180' : ''}`}
           fill="none"
           stroke="currentColor"
           viewBox="0 0 24 24"
@@ -31,23 +35,28 @@ export default function CourseSelect({ selected, onChange }: CourseSelectProps) 
           <path strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
         </svg>
       </div>
+
       {isOpen && (
         <div className="absolute z-10 bg-white border border-[#BDBDBD] rounded mt-1 w-full shadow-md">
-          {courseList.map((course) => (
-            <div
-              key={course}
-              onClick={() => {
-                onChange(course)
-                setIsOpen(false)
-              }}
-              className={`px-4 py-2 text-[14px] flex justify-between items-center cursor-pointer
-                ${selected === course ? 'text-[#6201E0] font-semibold bg-purple-50' : 'text-[#121212]'}
-                hover:bg-purple-100 hover:text-[#6201E0]`}
-            >
-              <span>{course}</span>
-              {selected === course && <IoCheckmark size={16} />}
-            </div>
-          ))}
+          {courseList.map((course) => {
+            const isSelected = selected === course
+            return (
+              <div
+                key={course}
+                onClick={() => {
+                  onChange(course)
+                  onClose()
+                }}
+                className={`py-2 px-[12px] text-[14px] ml-[12px] mt-[5px] w-[324px] h-[48px] flex justify-between 
+                  items-center rounded-[3px] cursor-pointer
+                  ${isSelected ? 'text-[#6201E0] font-semibold' : 'text-[#121212]'}
+                  hover:bg-[#efe6fc]`}
+              >
+                <span>{course}</span>
+                {isSelected && <IoCheckmark size={16} />}
+              </div>
+            )
+          })}
         </div>
       )}
     </div>

--- a/src/components/modals/RegisterStudentModal/RegisterStudentModal.tsx
+++ b/src/components/modals/RegisterStudentModal/RegisterStudentModal.tsx
@@ -7,10 +7,10 @@ import ClassSelect from './ClassSelect'
 import { IoCheckmark } from "react-icons/io5";
 import { useState } from 'react'
 
-
 export default function RegisterStudentModal({ onClose }: { onClose: () => void }) {
   const [selectedCourse, setSelectedCourse] = useState('')
   const [selectedClass, setSelectedClass] = useState('')
+  const [openSelect, setOpenSelect] = useState<'course' | 'class' | null>(null)
 
   return (
     <ModalWrapper width="w-[396px] h-[410px]">
@@ -21,12 +21,29 @@ export default function RegisterStudentModal({ onClose }: { onClose: () => void 
         description="해당하는 과정과 기수를 선택해 주세요."
         className="mt-[18px]"
       />
-      <div className="w-full">
 
-      <CourseSelect selected={selectedCourse} onChange={setSelectedCourse} />
-      <ClassSelect selected={selectedClass} onChange={setSelectedClass} />
+      <div className="w-full">
+        <CourseSelect
+          selected={selectedCourse}
+          onChange={setSelectedCourse}
+          isOpen={openSelect === 'course'}
+          onOpen={() => setOpenSelect('course')}
+          onClose={() => setOpenSelect(null)}
+        />
+
+        <ClassSelect
+          selected={selectedClass}
+          onChange={setSelectedClass}
+          // disabled={!selectedCourse} ← 이거 제거!
+          isOpen={openSelect === 'class'}
+          onOpen={() => setOpenSelect('class')}
+          onClose={() => setOpenSelect(null)}
+        />
       </div>
-      <Button className="bg-[#6201E0] text-white font-normal mt-6 cursor-pointer">등록 하기</Button>
+
+      <Button className="bg-[#6201E0] text-white font-normal mt-6 cursor-pointer">
+        등록 하기
+      </Button>
     </ModalWrapper>
   )
 }


### PR DESCRIPTION
## ✅ PR 요약

- 관련 이슈 번호 : 
- 작업요약 : 과정 선택 후에만 기수 선택 가능하도록 드롭다운 상태 제어 로직 추가

<!-- ex: feat: 로그인 페이지 구현 -->

## 📋 상세 내용

<!-- 어떤 작업을 했는지 간단히 설명 -->

- CourseSelect, ClassSelect 드롭다운이 동시에 열리지 않도록 openSelect 상태로 제어
- 과정 선택(CourseSelect)이 완료되어야만 기수 선택(ClassSelect)이 가능하도록 disabled 조건 추가

## 📸 스크린샷 (선택)
<img width="1689" alt="스크린샷 2025-07-09 오후 3 06 24" src="https://github.com/user-attachments/assets/0b863aa8-f8a3-475b-8664-bed8d670ef17" />

<!-- UI 변경 시 첨부 -->

## 📝 기타 참고사항

## 🧪 PR Check

<!-- 직접 테스트한 내용, 어떻게 동작을 확인했는지 작성 -->

- [x] 정상 동작 확인
- [x] UI 렌더링 확인
- [x] 기능 동작 확인
- [x] lint, type-check, build 오류 확인
