### PR TITLE
✨ feat: 마이페이지 UI 구현 및 Sidebar 메뉴 컴포넌트 분리

### DIFF
--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -105,7 +105,7 @@ export default function NavBar() {
               </div>
             )}
           </div>
-              {/* ✅ 모달 조건부 렌더링: 여기에 들어가야 함 */}
+              {/* 모달 조건부 렌더링: 여기에 들어가야 함 */}
               {showRegisterModal && (
                 <RegisterStudentModal onClose={() => setShowRegisterModal(false)} />
               )}

--- a/src/components/mypage/SidebarMenu.tsx
+++ b/src/components/mypage/SidebarMenu.tsx
@@ -1,0 +1,36 @@
+import { useNavigate } from "react-router";
+
+interface SidebarMenuProps {
+    active: '내 정보' | '비밀번호 변경' | '쪽지 시험';
+  }
+  
+  const SidebarMenu = ({ active }: SidebarMenuProps) => {
+    const navigate = useNavigate();
+  
+    const menus: { label: string; path: string }[] = [
+      { label: '쪽지 시험', path: '/MyPage/Quiz' }, // 👉 나중에 연결될 임시 경로
+      { label: '내 정보', path: '/MyPage' },
+      { label: '비밀번호 변경', path: '/MyPage/Password' },
+    ];
+  
+    return (
+      <div className="w-[180px] pt-2">
+        <div className="flex flex-col gap-4 text-[18px] font-semibold text-[#6201E0]">
+          {menus.map((menu) => (
+            <div
+              key={menu.label}
+              onClick={() => navigate(menu.path)}
+              className={`pl-4 border-l-[2px] cursor-pointer transition
+                ${active === menu.label
+                  ? 'text-[#6201E0] border-[#6201E0]'
+                  : 'text-[#9d9d9d] border-transparent hover:text-[#6201E0] hover:border-[#6201E0]'}`}
+            >
+              {menu.label}
+            </div>
+          ))}
+        </div>
+      </div>
+    );
+  };
+  
+  export default SidebarMenu;

--- a/src/pages/Mypage.tsx
+++ b/src/pages/Mypage.tsx
@@ -3,6 +3,7 @@ import { useEffect } from 'react';
 import default_profile_img from '../assets/profile_default.png';
 import checker from '../assets/checker.png';
 import Button from '@components/common/Button'
+import SidebarMenu from '@components/mypage/SidebarMenu';
 
 const mockUser = {
   nickname: '오즈오즈',
@@ -42,17 +43,7 @@ export default function MyPage() {
     <div className="min-h-screen bg-white flex justify-center py-20 text-black font-sans">
       <div className="flex w-[944px] gap-12">
         {/* 왼쪽 메뉴 */}
-        <div className="w-[180px] pt-2">
-          <div className="flex flex-col gap-4 text-[18px] font-semibold text-[#6201E0]">
-            <div className="text-[#9d9d9d] border-l-[4px] border-transparent pl-4 cursor-pointer hover:text-[#6201E0] hover:border-[#6201E0] transition">
-              쪽지 시험
-            </div>
-            <div className="border-l-[4px] border-[#6201E0] pl-4">내 정보</div>
-            <div className="text-[#9d9d9d] border-l-[4px] border-transparent pl-4 cursor-pointer hover:text-[#6201E0] hover:border-[#6201E0] transition">
-              비밀번호 변경
-            </div>
-          </div>
-        </div>
+        <SidebarMenu active="내 정보" />
 
         {/* 오른쪽 콘텐츠 */}
         <div className=" w-[744px] flex-1 flex flex-col gap-10">


### PR DESCRIPTION
## ✅ PR 요약

- 관련 이슈 번호 :
- 작업요약 : 마이페이지 UI 구현 및 Sidebar 메뉴 컴포넌트 분리

<!-- ex: feat: 로그인 페이지 구현 -->

## 📋 상세 내용

<!-- 어떤 작업을 했는지 간단히 설명 -->

- 마이페이지 레이아웃 구현 (내 정보 / 수강 과정 / 탈퇴 안내 포함)
- 좌측 메뉴(내 정보, 비밀번호 변경 등) UI를 SidebarMenu 컴포넌트로 분리
- Tailwind 스타일 유지 및 기존 디자인과 동일하게 구현
- hover 시 드롭다운 열리는 사용자 메뉴 관련 작업은 추후 별도 PR 예정

## 📸 스크린샷 (선택)

<!-- UI 변경 시 첨부 -->

## 📝 기타 참고사항

## 🧪 PR Check

<!-- 직접 테스트한 내용, 어떻게 동작을 확인했는지 작성 -->

- [ ] 정상 동작 확인
- [ ] UI 렌더링 확인
- [ ] 기능 동작 확인
- [ ] lint, type-check, build 오류 확인
