### PR TITLE
✨ feat: 비밀번호 변경 페이지 및 폼 컴포넌트 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import JoinFrom from './components/join/JoinForm'
 import NotFound from './pages/NotFound'
 import MyPage from "@pages/Mypage.tsx";
 import MyPageEdit from "@pages/MypageEdit.tsx";
+import ChangePwPage from '@pages/ChangePwPage';
 
 export default function App() {
   return (
@@ -26,6 +27,7 @@ export default function App() {
         <Route path="/Join/JoinForm" element={<JoinFrom />} />
         <Route path="/Mypage" element={<MyPage />} />
         <Route path="/MyPage/MyPageEdit" element={<MyPageEdit />} />
+        <Route path="/MyPage/Password" element={<ChangePwPage />} />
         <Route path="*" element={<NotFound />} />
       </Route>
     </Routes>

--- a/src/components/mypage/ChangePwForm.tsx
+++ b/src/components/mypage/ChangePwForm.tsx
@@ -1,0 +1,80 @@
+import { useState } from 'react';
+import Input from '@components/common/Input';
+import Button from '@components/common/Button';
+
+
+const ChangePwForm = () => {
+    const [newPw, setNewPw] = useState('');
+    const [confirmPw, setConfirmPw] = useState('');
+  
+    const isPwValid = newPw.length >= 8;
+    const isPwMatch = newPw === confirmPw;
+  
+    const isFormValid = isPwValid && isPwMatch;
+  
+    const handleSubmit = (e: React.FormEvent) => {
+      e.preventDefault();
+      if (!isFormValid) return;
+      // TODO: API 연결 등 로직
+    };
+  
+    return (
+      <form onSubmit={handleSubmit} className="flex flex-col gap-[20px]">
+        {/* 새 비밀번호 */}
+        <div className="flex items-center gap-[20px]">
+          <label className="w-[120px] text-[16px] text-[#121212] leading-[48px]">
+            새 비밀번호
+          </label>
+          <Input
+            type="password"
+            placeholder="새 비밀번호를 입력해주세요."
+            value={newPw}
+            onChange={(e) => setNewPw(e.target.value)}
+            error={newPw.length > 0 && !isPwValid}
+            success={isPwValid}
+            focusBorderColor="focus:border-[#6201E0]"
+            fullWidth={false}
+            noMarginBottom
+            className="w-[533px]"
+          />
+      </div>
+  
+        {/* 비밀번호 확인 */}
+        <div className="flex items-center gap-[20px]">
+          <label className="w-[120px] text-[16px] text-[#121212] leading-[48px]">
+            새 비밀번호 확인
+          </label>
+          <Input
+            type="password"
+            placeholder="새 비밀번호를 한 번 더 입력해주세요."
+            value={confirmPw}
+            onChange={(e) => setConfirmPw(e.target.value)}
+            error={confirmPw.length > 0 && !isPwMatch}
+            success={isPwMatch && confirmPw.length > 0}
+            focusBorderColor="focus:border-[#6201E0]"
+            fullWidth={false}
+            noMarginBottom
+            className="w-[533px]"
+          />
+      </div>
+  
+        {/* 버튼 */}
+        <div className="flex justify-end mt-[10px]">
+          <Button
+            type="submit"
+            fullWidth={false}
+            className={`w-[120px] ${
+              isFormValid
+                ? 'bg-[#6201E0] text-white'
+                : 'bg-[#E0E0E0] text-[#A0A0A0] cursor-not-allowed'
+            }`}
+            disabled={!isFormValid}
+          >
+            변경하기
+          </Button>
+        </div>
+      </form>
+    );
+  };
+  
+  export default ChangePwForm;

--- a/src/pages/ChangePwPage.tsx
+++ b/src/pages/ChangePwPage.tsx
@@ -1,0 +1,18 @@
+import ChangePwForm from '@components/mypage/ChangePwForm';
+import SidebarMenu from '@components/mypage/SidebarMenu';
+
+export default function ChangePwPage() {
+    return (
+      <div className="min-h-screen bg-white flex justify-center py-20">
+        <div className="flex w-[944px] gap-12">
+          <SidebarMenu active="비밀번호 변경" />
+          <div className="flex-1">
+            <h1 className="text-[32px] font-semibold mb-[20px]">비밀번호 변경</h1>
+            <div className="border border-[#E0E0E0] rounded px-[40px] py-[48px] w-[744px]">
+              <ChangePwForm />
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }


### PR DESCRIPTION
## ✅ PR 요약

- 관련 이슈 번호 : 
- 작업요약 : 마이페이지 내 비밀번호 변경 페이지 신규 구현

<!-- ex: feat: 로그인 페이지 구현 -->

## 📋 상세 내용

<!-- 어떤 작업을 했는지 간단히 설명 -->

- `ChangePwPage.tsx`: 마이페이지 사이드바 포함한 페이지 조립
- `ChangePwForm.tsx`: 비밀번호 변경 폼 구현
  - 새 비밀번호 / 비밀번호 확인 인풋 필드 구성
  - 비밀번호 유효성 검사 (8자 이상 & 일치 여부)
  - 버튼 활성화 조건 처리
- `SidebarMenu.tsx`: 기존 컴포넌트 재사용
- 공통 컴포넌트 `Input`, `Button` 활용

## 📸 스크린샷 (선택)
<img width="1710" alt="스크린샷 2025-07-10 오후 4 08 49" src="https://github.com/user-attachments/assets/8af64be9-64c1-44a5-a433-ca488ba53596" />

<!-- UI 변경 시 첨부 -->

## 📝 기타 참고사항
- 추후 비밀번호 보기 토글 및 문구 유효성 메시지 추가 예정

## 🧪 PR Check

<!-- 직접 테스트한 내용, 어떻게 동작을 확인했는지 작성 -->

- [ ] 정상 동작 확인
- [ ] UI 렌더링 확인
- [ ] 기능 동작 확인
- [ ] lint, type-check, build 오류 확인
