### PR TITLE
✨ feat: 비밀번호 변경 페이지 UI 및 유효성 메시지 구현

### DIFF
--- a/src/components/mypage/ChangePwForm.tsx
+++ b/src/components/mypage/ChangePwForm.tsx
@@ -1,45 +1,68 @@
 import { useState } from 'react';
+import { GoEye, GoEyeClosed } from "react-icons/go";
 import Input from '@components/common/Input';
 import Button from '@components/common/Button';
 
-
 const ChangePwForm = () => {
-    const [newPw, setNewPw] = useState('');
-    const [confirmPw, setConfirmPw] = useState('');
-  
-    const isPwValid = newPw.length >= 8;
-    const isPwMatch = newPw === confirmPw;
-  
-    const isFormValid = isPwValid && isPwMatch;
-  
-    const handleSubmit = (e: React.FormEvent) => {
-      e.preventDefault();
-      if (!isFormValid) return;
-      // TODO: API 연결 등 로직
-    };
-  
-    return (
-      <form onSubmit={handleSubmit} className="flex flex-col gap-[20px]">
-        {/* 새 비밀번호 */}
+  const [newPw, setNewPw] = useState('');
+  const [confirmPw, setConfirmPw] = useState('');
+  const [showPw, setShowPw] = useState(false);
+  const [isPwFocused, setIsPwFocused] = useState(false);
+
+  const isPwValid = newPw.length >= 8;
+  const isPwMatch = newPw === confirmPw;
+  const isFormValid = isPwValid && isPwMatch;
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!isFormValid) return;
+    // TODO: API 연결 등
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="flex flex-col gap-[20px]">
+      {/* 새 비밀번호 */}
+      <div>
         <div className="flex items-center gap-[20px]">
           <label className="w-[120px] text-[16px] text-[#121212] leading-[48px]">
             새 비밀번호
           </label>
-          <Input
-            type="password"
-            placeholder="새 비밀번호를 입력해주세요."
-            value={newPw}
-            onChange={(e) => setNewPw(e.target.value)}
-            error={newPw.length > 0 && !isPwValid}
-            success={isPwValid}
-            focusBorderColor="focus:border-[#6201E0]"
-            fullWidth={false}
-            noMarginBottom
-            className="w-[533px]"
-          />
+          <div className="relative w-[533px]">
+            <Input
+              type={showPw ? 'text' : 'password'}
+              placeholder="새 비밀번호를 입력해주세요."
+              value={newPw}
+              onChange={(e) => setNewPw(e.target.value)}
+              onFocus={() => setIsPwFocused(true)}
+              onBlur={() => setIsPwFocused(false)}
+              error={newPw.length > 0 && !isPwValid}
+              success={isPwValid}
+              focusBorderColor="focus:border-[#121212]"
+              fullWidth={false}
+              noMarginBottom
+              className="w-[533px] pr-[44px]"
+            />
+            {isPwValid && (
+              <button
+                type="button"
+                onClick={() => setShowPw((prev) => !prev)}
+                className="absolute right-[12px] top-1/2 -translate-y-1/2 text-[#4D4D4D] focus:outline-none"
+              >
+                {showPw ? <GoEye size={18} /> : <GoEyeClosed size={18} />}
+              </button>
+            )}
+          </div>
+        </div>
+        {/* 유효성 메시지 */}
+        {isPwFocused && (
+          <p className="text-[12px] text-[#9d9d9d] mt-[8px] ml-[130px]">
+            * 6~15자의 영문 대/소문자, 숫자 및 특수문자 조합
+          </p>
+        )}
       </div>
-  
-        {/* 비밀번호 확인 */}
+
+      {/* 비밀번호 확인 */}
+      <div>
         <div className="flex items-center gap-[20px]">
           <label className="w-[120px] text-[16px] text-[#121212] leading-[48px]">
             새 비밀번호 확인
@@ -51,30 +74,42 @@ const ChangePwForm = () => {
             onChange={(e) => setConfirmPw(e.target.value)}
             error={confirmPw.length > 0 && !isPwMatch}
             success={isPwMatch && confirmPw.length > 0}
-            focusBorderColor="focus:border-[#6201E0]"
+            focusBorderColor="focus:border-[#121212]"
             fullWidth={false}
             noMarginBottom
             className="w-[533px]"
           />
-      </div>
-  
-        {/* 버튼 */}
-        <div className="flex justify-end mt-[10px]">
-          <Button
-            type="submit"
-            fullWidth={false}
-            className={`w-[120px] ${
-              isFormValid
-                ? 'bg-[#6201E0] text-white'
-                : 'bg-[#E0E0E0] text-[#A0A0A0] cursor-not-allowed'
-            }`}
-            disabled={!isFormValid}
-          >
-            변경하기
-          </Button>
         </div>
-      </form>
-    );
-  };
-  
-  export default ChangePwForm;
+        {/* 유효성 메시지 */}
+        {isPwMatch && confirmPw.length > 0 && (
+          <p className="text-[12px] text-[#00C27C] mt-[8px] ml-[130px]">
+            * 비밀번호가 일치합니다.
+          </p>
+        )}
+        {!isPwMatch && confirmPw.length > 0 && (
+          <p className="text-[12px] text-[#EC0037] mt-[8px] ml-[130px]">
+            * 비밀번호가 일치하지 않습니다.
+          </p>
+        )}
+      </div>
+
+      {/* 버튼 */}
+      <div className="flex justify-end mt-[10px]">
+      <Button
+        type="submit"
+        fullWidth={false}
+        className={`w-[120px] text-white rounded cursor-pointer ${
+          isFormValid
+            ? 'bg-[#6201E0] hover:bg-[#4e01b3] active:bg-[#3b0186]'
+            : 'bg-[#E0E0E0] text-[#A0A0A0] cursor-not-allowed'
+        }`}
+        disabled={!isFormValid}
+      >
+        변경하기
+      </Button>
+      </div>
+    </form>
+  );
+};
+
+export default ChangePwForm;


### PR DESCRIPTION
## ✅ PR 요약

- 관련 이슈 번호 : 
- 작업요약 : 비밀번호 변경 페이지 및 기능 UI 구현

<!-- ex: feat: 로그인 페이지 구현 -->

## 📋 상세 내용

<!-- 어떤 작업을 했는지 간단히 설명 -->

- 비밀번호 입력 및 확인 Input UI 구현
- 눈 아이콘을 활용한 비밀번호 보기/숨기기 기능 추가
- 포커스 시 유효성 안내 문구 표시
- 비밀번호 확인 시 일치/불일치 메시지 조건부 출력
- 변경하기 버튼 활성화 조건 및 색상 스타일 설정 (Default / Hover / Active)
- Tailwind 기반 스타일링 반영 및 재사용 가능한 Input, Button 컴포넌트 활용

## 📸 스크린샷 (선택)
<img width="1710" alt="스크린샷 2025-07-10 오후 5 50 50" src="https://github.com/user-attachments/assets/f9a6a030-013c-4adf-9110-c4a5965dc5e9" />

<!-- UI 변경 시 첨부 -->

## 📝 기타 참고사항

## 🧪 PR Check

<!-- 직접 테스트한 내용, 어떻게 동작을 확인했는지 작성 -->

- [x] 정상 동작 확인
- [x] UI 렌더링 확인
- [x] 기능 동작 확인
- [x] lint, type-check, build 오류 확인
