### PR TITLE
✨ feat : access 토큰 만료 시 refresh 토큰 자동 요청

### DIFF
--- a/src/api/mainApi.ts
+++ b/src/api/mainApi.ts
@@ -1,5 +1,5 @@
 import type { userData } from '@customType/userData'
-import axios from 'axios'
+import axios, { type AxiosRequestConfig } from 'axios'
 
 // 인스턴스 생성
 const api = axios.create({
@@ -7,6 +7,7 @@ const api = axios.create({
   timeout: 5000,
   headers: {
     'Content-Type': 'application/json', // 공통 헤더
+    Authorization: '',
   },
   withCredentials: true,
 })
@@ -29,29 +30,52 @@ api.interceptors.request.use(
   }
 )
 
-// export const testApi = axios.create({
-//   baseURL: import.meta.env.VITE_API_BASE_URL,
-//   timeout: 5000,
-//   headers: {
-//     'Content-Type': 'application/json',
-//   },
-// })
+const refreshAccessToken = async () => {
+  const userInfo = localStorage.getItem('userInfo')
+  if (!userInfo) throw new Error('No userInfo found in localStorage')
 
-// testApi.interceptors.request.use(
-//   (config) => {
-//     const userInfo = localStorage.getItem('userInfo')
+  const parsed: { state: { userInfo: userData } } = JSON.parse(userInfo)
+  const refreshToken = parsed.state.userInfo.refresh
+  if (!refreshToken) throw new Error('No refresh token found')
 
-//     if (userInfo) {
-//       const parsed: userData = JSON.parse(userInfo)
-//       const token = parsed.access
-//       config.headers.Authorization = `Bearer ${token}`
-//     }
-//     return config
-//   },
-//   (error) => {
-//     console.error('Request error:', error)
-//     return Promise.reject(error)
-//   }
-// )
+  const res = await axios.post('v1/auth/token/refresh/', {
+    refresh: refreshToken,
+  })
+
+  const newAccessToken: string = res.data.accessToken
+  parsed.state.userInfo.access = newAccessToken
+  localStorage.setItem('userInfo', JSON.stringify(parsed))
+
+  return newAccessToken
+}
+
+api.interceptors.response.use(
+  (response) => response,
+  async (error) => {
+    const originalRequest = error.config as AxiosRequestConfig & {
+      _retry?: boolean
+    }
+    if (
+      error.response &&
+      error.response.status === 401 &&
+      !originalRequest._retry
+    ) {
+      originalRequest._retry = true
+      try {
+        const newAccessToken = await refreshAccessToken()
+        originalRequest.headers = {
+          ...originalRequest.headers,
+          Authorization: `Bearer ${newAccessToken}`,
+        }
+        return api(originalRequest)
+      } catch (refreshError) {
+        localStorage.removeItem('userInfo')
+        window.location.href = '/login'
+        return Promise.reject(refreshError)
+      }
+    }
+    return Promise.reject(error)
+  }
+)
 
 export default api


### PR DESCRIPTION
## ✅ PR 요약

- 관련 이슈 번호 : #119 
- 작업요약 : axios 응답 인터셉터 추가(엑세스토큰 재발급)

<!-- ex: feat: 로그인 페이지 구현 -->

## 📋 상세 내용

<!-- 어떤 작업을 했는지 간단히 설명 -->

- axios 인스턴스에서 응답을 인터셉터하여 401 err 발생 시 엑세스토큰 재발급 

## 📸 스크린샷 (선택)

<!-- UI 변경 시 첨부 -->

## 📝 기타 참고사항

## 🧪 PR Check

<!-- 직접 테스트한 내용, 어떻게 동작을 확인했는지 작성 -->

- [x] 정상 동작 확인
- [x] UI 렌더링 확인
- [x] 기능 동작 확인
- [x] lint, type-check, build 오류 확인
